### PR TITLE
Make Kafunk easier to build in CI

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -380,7 +380,7 @@ Target "All" DoNothing
   ==> "All"
   =?> ("ReleaseDocs",isLocalBuild)
 
-"All"
+"CopyBinaries"
 #if MONO
 #else
   =?> ("SourceLink", Pdbstr.tryFind().IsSome )


### PR DESCRIPTION
For basic CI systems, we'd like to separate the artifact creation process from the documentation and test process. This isn't always the case but the flexibility is necessary if they are performed separately.