### PR TITLE
End of topic poll policy, commit consumer offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ This is a work in progress and not yet published as a packge. See the issue list
 # Hello World
 
 ```fsharp
-
 open Kafunk
 
-// connect
 
 let conn = Kafka.connHost "existential-host"
 
@@ -78,8 +76,27 @@ consumer
 |> Consumer.consume (fun tn p ms commit -> async {
   printfn "topic=%s partition=%i" tn p
   do! commit })
-|> Async.RunSynchronously  
+|> Async.RunSynchronously
 
+
+
+// consumer offsets
+
+Consumer.commitOffsets consumer [| "absurd-topic", [| 0, 1L |] |]
+|> Async.RunSynchronously
+
+
+
+// offsets
+
+let offsets = 
+  Kafka.Composite.offsets conn "absurd-topic" [ Time.EarliestOffset ; Time.LatestOffset ] 1
+  |> Async.RunSynchronously
+
+for kvp in offsets do
+  for (tn,offsets) in kvp.Value.topics do
+    for p in offsets do
+      printfn "time=%i topic=%s partition=%i offsets=%A" kvp.Key tn p.partition p.offsets
 ```
 
 # Maintainer(s)

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -67,7 +67,27 @@ consumer
 |> Consumer.consume (fun tn p ms commit -> async {
   printfn "topic=%s partition=%i" tn p
   do! commit })
-|> Async.RunSynchronously  
+|> Async.RunSynchronously
+
+
+
+// consumer offsets
+
+Consumer.commitOffsets consumer [| "absurd-topic", [| 0, 1L |] |]
+|> Async.RunSynchronously
+
+
+
+// offsets
+
+let offsets = 
+  Kafka.Composite.offsets conn "absurd-topic" [ Time.EarliestOffset ; Time.LatestOffset ] 1
+  |> Async.RunSynchronously
+
+for kvp in offsets do
+  for (tn,offsets) in kvp.Value.topics do
+    for p in offsets do
+      printfn "time=%i topic=%s partition=%i offsets=%A" kvp.Key tn p.partition p.offsets
 
 
 

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -492,7 +492,9 @@ module Chan =
               Log.trace "received_response|response=%A" (ResponseMessage.Print res)
             | Failure _ -> 
               Log.warn "request_timed_out|ep=%O request=%s timeout=%O" ep (RequestMessage.Print req) config.requestTimeout)
-      |> Faults.AsyncFunc.retryResultThrowList (fun _timouts -> TimeoutException()) config.requestRetryPolicy
+      |> Faults.AsyncFunc.retryResultThrowList 
+          (fun timeouts -> TimeoutException(sprintf "Broker request retries terminated after %i timeouts." timeouts.Length)) 
+          config.requestRetryPolicy
 
     return Chan (ep, send, Async.empty, Async.empty) }
 

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -363,9 +363,9 @@ type ChanConfig = {
       receiveBufferSize = defaultArg receiveBufferSize 8192
       sendBufferSize = defaultArg sendBufferSize 8192
       connectTimeout = defaultArg connectTimeout (TimeSpan.FromSeconds 10)
-      connectRetryPolicy = defaultArg connectRetryPolicy (RetryPolicy.constantMs 1000 |> RetryPolicy.maxAttempts 5)
+      connectRetryPolicy = defaultArg connectRetryPolicy (RetryPolicy.constantMs 2000 |> RetryPolicy.maxAttempts 50)
       requestTimeout = defaultArg requestTimeout (TimeSpan.FromSeconds 10)
-      requestRetryPolicy = defaultArg requestRetryPolicy (RetryPolicy.constantMs 1000 |> RetryPolicy.maxAttempts 5)
+      requestRetryPolicy = defaultArg requestRetryPolicy (RetryPolicy.constantMs 2000 |> RetryPolicy.maxAttempts 50)
     }
 
 
@@ -450,11 +450,12 @@ module Chan =
 
     /// fault tolerant receive operation
     let! receive =
-      let receive s buf = async {
-        let! received = Socket.receive s buf
-        if received = 0 then return raise(SocketException(int SocketError.ConnectionAborted)) 
-        else return received }
-      socketAgent |> Resource.inject receive
+//      let receive s buf = async {
+//        let! received = Socket.receive s buf
+//        if received = 0 then return raise(SocketException(int SocketError.ConnectionAborted)) 
+//        else return received }
+      //socketAgent |> Resource.inject receive
+      socketAgent |> Resource.inject Socket.receive
 
     /// An unframed input stream.
     let inputStream =

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -335,7 +335,7 @@ type EndPoint =
 /// A request/reply channel to a Kafka broker.
 type Chan = 
   private 
-  | Chan of send:(RequestMessage -> Async<ResponseMessage>) * reconnect:Async<unit> * close:Async<unit>
+  | Chan of ep:EndPoint * send:(RequestMessage -> Async<ResponseMessage>) * reconnect:Async<unit> * close:Async<unit>
 
 
 /// Configuration for an individual TCP channel.
@@ -362,10 +362,10 @@ type ChanConfig = {
       useNagle = defaultArg useNagle false
       receiveBufferSize = defaultArg receiveBufferSize 8192
       sendBufferSize = defaultArg sendBufferSize 8192
-      connectTimeout = defaultArg connectTimeout (TimeSpan.FromSeconds 10.0)
-      connectRetryPolicy = defaultArg connectRetryPolicy (RetryPolicy.constant 1000 |> RetryPolicy.maxAttempts 5)
-      requestTimeout = defaultArg requestTimeout (TimeSpan.FromSeconds 30.0)
-      requestRetryPolicy = defaultArg requestRetryPolicy (RetryPolicy.constant 1000 |> RetryPolicy.maxAttempts 5)
+      connectTimeout = defaultArg connectTimeout (TimeSpan.FromSeconds 10)
+      connectRetryPolicy = defaultArg connectRetryPolicy (RetryPolicy.constantMs 1000 |> RetryPolicy.maxAttempts 5)
+      requestTimeout = defaultArg requestTimeout (TimeSpan.FromSeconds 30)
+      requestRetryPolicy = defaultArg requestRetryPolicy (RetryPolicy.constantMs 1000 |> RetryPolicy.maxAttempts 5)
     }
 
 
@@ -376,10 +376,13 @@ module Chan =
   let private Log = Log.create "Kafunk.Chan"
 
   /// Sends a request.
-  let send (Chan(send,_,_)) req = send req
+  let send (Chan(_,send,_,_)) req = send req
   
-  /// Re-established the connection to the socket.
-  let reconnect (Chan(_,reconnect,_)) = reconnect
+  /// Gets the endpoint.
+  let endpoint (Chan(ep,_,_,_)) = ep
+
+//  /// Re-established the connection to the socket.
+//  let reconnect (Chan(_,reconnect,_)) = reconnect
 
   let metadata = AsyncFunc.dimap RequestMessage.Metadata ResponseMessage.toMetadata
   let fetch = AsyncFunc.dimap RequestMessage.Fetch ResponseMessage.toFetch
@@ -400,60 +403,58 @@ module Chan =
   /// Only a single channel per endpoint is needed.
   let connect (config:ChanConfig) (clientId:ClientId) (ep:EndPoint) : Async<Chan> = async {
 
-    let ep = EndPoint.endpoint ep
-
-    /// Builds and connects the socket to the broker.
-    let conn = async {
+    let conn (ep:EndPoint) = async {
+      let ipep = EndPoint.endpoint ep
       let connSocket =
         new Socket(
-          ep.AddressFamily,
+          ipep.AddressFamily,
           SocketType.Stream,
           ProtocolType.Tcp,
           NoDelay=not(config.useNagle),
           ExclusiveAddressUse=true,
           ReceiveBufferSize=config.receiveBufferSize,
           SendBufferSize=config.receiveBufferSize)
-      Log.info "tcp_connecting|remote_endpoint=%O client_id=%s" ep clientId 
-      let! sendRcvSocket = 
-        Socket.connect connSocket ep
-        |> Async.timeoutResult config.connectTimeout
-        |> Async.map (Result.mapError (fun _ -> new TimeoutException() :> exn))
-      match sendRcvSocket with
-      | Success socket -> 
-        Log.info "tcp_connected|remote_endpoint=%O local_endpoint=%O" socket.RemoteEndPoint socket.LocalEndPoint
-        return sendRcvSocket 
-      | Failure e ->
-        Log.error "tcp_connection_failed|remote_endpoint=%O error=%O" ep e
-        return sendRcvSocket }
-
+      return! Socket.connect connSocket ipep }
+    
     let conn =
       conn
-      |> Faults.retryResultThrow id Exn.monoid config.connectRetryPolicy
+      |> AsyncFunc.timeoutResult config.connectTimeout
+      |> AsyncFunc.catchResult
+      |> AsyncFunc.doBeforeAfter
+          (fun ep -> Log.info "tcp_connecting|remote_endpoint=%O client_id=%s" (EndPoint.endpoint ep) clientId)
+          (fun (ep,res) ->
+            let ipep = EndPoint.endpoint ep
+            match res with
+            | Success s ->
+              Log.info "tcp_connected|remote_endpoint=%O local_endpoint=%O" s.RemoteEndPoint s.LocalEndPoint
+            | Failure (Choice1Of2 _) ->
+              Log.error "tcp_connection_timed_out|remote_endpoint=%O timeout=%O" ipep config.connectTimeout
+            | Failure (Choice2Of2 e) ->
+              Log.error "tcp_connection_failed|remote_endpoint=%O error=%O" ipep e)
+      |> AsyncFunc.mapOut (snd >> Result.mapError (Choice.fold (fun e -> e :> exn) id))
+      |> Faults.AsyncFunc.retryResultThrow id Exn.monoid config.connectRetryPolicy
 
     let recovery (s:Socket, ver:int, _req:obj, ex:exn) = async {
-      Log.info "recovering_tcp_connection|client_id=%s remote_endpoint=%O version=%i socket_connected=%b error=%O" clientId ep ver s.Connected ex
+      Log.info "recovering_tcp_connection|client_id=%s remote_endpoint=%O version=%i error=%O" clientId (EndPoint.endpoint ep) ver ex
       tryDispose s
-      // TODO: inspect error type
       return Resource.Recovery.Recreate }
 
-    let! sendRcvSocket = 
+    let! socketAgent = 
       Resource.recoverableRecreate 
-        conn
+        (conn ep)
         recovery
 
     let! send =
-      sendRcvSocket
+      socketAgent
       |> Resource.inject Socket.sendAll
 
     /// fault tolerant receive operation
     let! receive =
-      let receive s = 
-        Socket.receive s
-        >> Async.map (fun received -> 
-          if received = 0 then raise(SocketException(int SocketError.ConnectionAborted)) 
-          else received)
-      sendRcvSocket 
-      |> Resource.inject receive
+      let receive s buf = async {
+        let! received = Socket.receive s buf
+        if received = 0 then return raise(SocketException(int SocketError.ConnectionAborted)) 
+        else return received }
+      socketAgent |> Resource.inject receive
 
     /// An unframed input stream.
     let inputStream =
@@ -484,19 +485,15 @@ module Chan =
       |> AsyncFunc.timeoutResult config.requestTimeout
       |> Faults.AsyncFunc.doAfterError
           (fun (req,e) ->
-            let v = sendRcvSocket.TryGetVersion () |> Option.getOr -1
+            let v = socketAgent.TryGetVersion () |> Option.getOr -1
             Log.warn "request_timed_out|ep=%O resource_version=%i request=%s timeout=%O error=%O" ep v (RequestMessage.Print req) config.requestTimeout e)
-      |> Faults.AsyncFunc.retryResultThrowList (Exn.ofSeq) config.requestRetryPolicy
+      |> Faults.AsyncFunc.retryResultThrowList Exn.ofSeq config.requestRetryPolicy
       |> AsyncFunc.doBeforeAfterExn 
           (fun a -> Log.trace "sending_request|request=%A" (RequestMessage.Print a))
           (fun (_,b) -> Log.trace "received_response|response=%A" (ResponseMessage.Print b))
           (fun (a,e) -> Log.error "request_errored|request=%A error=%O" (RequestMessage.Print a) e)
 
-    return Chan (send, async.Delay (sendRcvSocket.Recreate), Async.empty) }
-
-  let connectEndPoint (config:ChanConfig) (clientId:ClientId) (ep:EndPoint) = async {
-    let! ch = connect config clientId ep
-    return (ep,ch) }
+    return Chan (ep, send, Async.empty, Async.empty) }
 
   let connectHost (config:ChanConfig) (clientId:ClientId) (host:Host, port:Port) = async {
     let! ip = async {
@@ -510,4 +507,4 @@ module Chan =
       | Some ip ->
         return ip }
     let ep = EndPoint.ofIPAddressAndPort (ip, port)
-    return! connectEndPoint config clientId ep }
+    return! connect config clientId ep }

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -486,7 +486,7 @@ module Chan =
           (fun (req,e) ->
             let v = sendRcvSocket.TryGetVersion () |> Option.getOr -1
             Log.warn "request_timed_out|ep=%O resource_version=%i request=%s timeout=%O error=%O" ep v (RequestMessage.Print req) config.requestTimeout e)
-      |> Faults.AsyncFunc.retryResultThrowList (fun _times -> TimeoutException() :> exn)  config.requestRetryPolicy
+      |> Faults.AsyncFunc.retryResultThrowList (Exn.ofSeq) config.requestRetryPolicy
       |> AsyncFunc.doBeforeAfterExn 
           (fun a -> Log.trace "sending_request|request=%A" (RequestMessage.Print a))
           (fun (_,b) -> Log.trace "received_response|response=%A" (ResponseMessage.Print b))

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -30,7 +30,7 @@ type ConsumerConfig = {
         heartbeatFrequency = defaultArg heartbeatFrequency 10
         fetchMinBytes = defaultArg fetchMinBytes 0
         fetchMaxWaitMs = defaultArg fetchMaxWaitMs 0
-        fetchBufferBytes = defaultArg fetchBufferBytes 1000000
+        fetchBufferBytes = defaultArg fetchBufferBytes 100000
         offsetRetentionTime = defaultArg offsetRetentionTime -1L
         initialFetchTime = defaultArg initialFetchTime Time.EarliestOffset
         endOfTopicPollPolicy = defaultArg endOfTopicPollPolicy (RetryPolicy.constantMs 10000)
@@ -182,7 +182,7 @@ module Consumer =
       match ec with
       | ErrorCode.UnknownMemberIdCode -> 
         Log.warn "resetting_member_id"
-        do! Async.Sleep cfg.sessionTimeout
+        //do! Async.Sleep cfg.sessionTimeout
         return! join consumer None
       | _ -> 
         return! join consumer prevMemberId

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -33,7 +33,7 @@ type ConsumerConfig = {
         fetchBufferBytes = defaultArg fetchBufferBytes 1000000
         offsetRetentionTime = defaultArg offsetRetentionTime -1L
         initialFetchTime = defaultArg initialFetchTime Time.EarliestOffset
-        endOfTopicPollPolicy = defaultArg endOfTopicPollPolicy (RetryPolicy.constant 10000)
+        endOfTopicPollPolicy = defaultArg endOfTopicPollPolicy (RetryPolicy.constantMs 10000)
       }
 
 /// State corresponding to a single generation of the consumer group protocol.
@@ -357,7 +357,7 @@ module Consumer =
         /// Poll on end of topic.
         let fetchAndPoll =
           fetch
-          |> Faults.AsyncFunc.retry
+          |> Faults.AsyncFunc.retryAsync
             (function
               | offset, Some (ms:MessageSet,highWatermarkOffset) ->
                 if ms.messages.Length = 0 then
@@ -399,9 +399,9 @@ module Consumer =
         let! state = MVar.get consumer.state
         let! topics = consume state
         yield state.generationId,topics
-        Log.info "waiting_on_group_to_close"
+        //Log.info "waiting_on_group_to_close"
         do! state.closed.Task |> Async.AwaitTask
-        Log.info "group_closed;rejoining"
+        //Log.info "group_closed;rejoining"
         let! _ = join consumer (Some state.memberId)
         () }
 

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -98,7 +98,7 @@ module Consumer =
 
       | Some prevMemberId -> 
         Log.info "rejoining_consumer_group|group_id=%s member_id=%s" cfg.groupId prevMemberId
-        do! conn.ReconnectChans ()
+        //do! conn.ReconnectChans ()
 
       let! _ = conn.GetGroupCoordinator (cfg.groupId)
 

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -67,6 +67,10 @@ module Consumer =
     if t.IsCompleted then return f t.Result
     else return! a }
 
+
+//  let (|FetchOK|FetchError|) (r:FetchResponse) =
+//    FetchOK
+
   /// Creates a participant in the consumer groups protocol.
   /// A generation changes when the group changes, such as when members join or leave.
   /// Each generation contains a set of async sequences corresponding to messages in a single topic-partition.

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -541,15 +541,15 @@ type KafkaConn internal (cfg:KafkaConnConfig) =
     let! _ = bootstrap cfg
     return () }
 
-  // TODO: reconsider this design!
-  member internal __.ReconnectChans () = async {
-    let state = __.GetState ()
-    let! _ =
-      state.channels
-      |> Map.toSeq
-      |> Seq.map (fun (_,ch) -> Chan.reconnect ch)
-      |> Async.Parallel
-    return () }
+//  // TODO: reconsider this design!
+//  member internal __.ReconnectChans () = async {
+//    let state = __.GetState ()
+//    let! _ =
+//      state.channels
+//      |> Map.toSeq
+//      |> Seq.map (fun (_,ch) -> Chan.reconnect ch)
+//      |> Async.Parallel
+//    return () }
 
   member internal __.GetGroupCoordinator (groupId:GroupId) = async {
     let state = __.GetState ()

--- a/src/kafunk/Tcp.fs
+++ b/src/kafunk/Tcp.fs
@@ -410,7 +410,7 @@ type ReqRepSession<'a, 'b, 's> internal
 
   do Async.Start(receiveLoop, cts.Token)
 
-  member x.Send (req:'a) = async {
+  member internal x.Send (req:'a) = async {
     let! ct = Async.CancellationToken
     let _correlationId,sessionData,rep = mux ct req
     //Log.trace "sending_request|correlation_id=%i bytes=%i" correlationId sessionData.Count
@@ -454,3 +454,6 @@ module Session =
     (receive:AsyncSeq<Binary.Segment>)
     (send:Binary.Segment -> Async<int>) =
       new ReqRepSession<'a, 'b, 's>(correlationId, encode, decode, awaitResponse, receive, send)
+
+  /// Sends a request on the session and awaits the response.
+  let send (session:ReqRepSession<_, _, _>) req = session.Send req

--- a/src/kafunk/Tcp.fs
+++ b/src/kafunk/Tcp.fs
@@ -56,20 +56,29 @@ module Socket =
   /// Executes an async socket operation.
   let exec (alloc:unit -> SocketAsyncEventArgs, free:SocketAsyncEventArgs -> unit) (config:SocketAsyncEventArgs -> unit) (op:SocketAsyncEventArgs -> bool) (map:SocketAsyncEventArgs -> 'a) =
     Async.FromContinuations <| fun (ok, error, _) ->
-      let args = alloc ()
-      config args
-      let rec k (_:obj) (args:SocketAsyncEventArgs) =
-        args.remove_Completed(k')
-        try
-          match args.SocketError with
-          | SocketError.Success -> ok (map args)
-          | e -> error (SocketException(int e))
-        finally
-          free args
-      and k' = EventHandler<SocketAsyncEventArgs>(k)
-      args.add_Completed(k')
-      if not (op args) then
+      try
+        let cnt = ref 0
+        let args = alloc ()
+        config args
+        let rec k (_:obj) (args:SocketAsyncEventArgs) =
+          if Interlocked.Increment cnt > 1 then
+            printfn "Socket|multiple continuation invokes!"
+          args.remove_Completed(k')
+          try
+            try
+              match args.SocketError with
+              | SocketError.Success -> ok (map args)
+              | e -> error (SocketException(int e))
+            finally
+              free args
+          with ex ->
+            printfn "Socket|ERROR|%O" ex
+        and k' = EventHandler<SocketAsyncEventArgs>(k)
+        args.add_Completed(k')
+        if not (op args) then
           k null args
+      with ex ->
+        error ex
 
   let argsAlloc =
     let pool = new ObjectPool<_>(10000, fun () -> new SocketAsyncEventArgs())
@@ -396,6 +405,7 @@ type ReqRepSession<'a, 'b, 's> internal
       return! receiveLoop
     with ex ->
       Log.error "receive_loop_faiure|error=%O" ex
+      //do! Async.Sleep 1000
       return! receiveLoop }
 
   do Async.Start(receiveLoop, cts.Token)

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -212,12 +212,12 @@ module AsyncEx =
     static member timeoutResultWith (f:unit -> 'e) (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, 'e>> =
       Async.timeoutWith (f >> Failure) timeout (c |> Async.map Success)
 
-    static member timeoutResult (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, TimeSpan>> =
-      Async.timeoutResultWith (fun () -> timeout) timeout c
+    static member timeoutResult (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, TimeoutException>> =
+      Async.timeoutResultWith (fun () -> TimeoutException(sprintf "The operation timed out after %fsec" timeout.TotalSeconds)) timeout c
 
     static member timeoutAfter (timeout:TimeSpan) (c:Async<'a>) =
       Async.timeoutResult timeout c 
-      |> Async.map (Result.throwMap (fun timeout -> TimeoutException(sprintf "The operation timed out after %fsec" timeout.TotalSeconds)))
+      |> Async.map (Result.throw)
 
 
 
@@ -266,7 +266,7 @@ module AsyncFunc =
   let timeout (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<'b> =
     fun a -> async.Delay (fun () -> f a) |> Async.timeoutAfter t
 
-  let timeoutResult (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<Result<'b, TimeSpan>> =
+  let timeoutResult (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<Result<'b, TimeoutException>> =
     fun a -> async.Delay (fun () -> f a) |> Async.timeoutResult t 
   
 

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -212,11 +212,12 @@ module AsyncEx =
     static member timeoutResultWith (f:unit -> 'e) (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, 'e>> =
       Async.timeoutWith (f >> Failure) timeout (c |> Async.map Success)
 
-    static member timeoutResult (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, TimeoutException>> =
-      Async.timeoutResultWith (fun () -> TimeoutException(sprintf "The operation timed out after %fsec" timeout.TotalSeconds)) timeout c
+    static member timeoutResult (timeout:TimeSpan) (c:Async<'a>) : Async<Result<'a, TimeSpan>> =
+      Async.timeoutResultWith (fun () -> timeout) timeout c
 
     static member timeoutAfter (timeout:TimeSpan) (c:Async<'a>) =
-      Async.timeoutResult timeout c |> Async.map Result.throw
+      Async.timeoutResult timeout c 
+      |> Async.map (Result.throwMap (fun timeout -> TimeoutException(sprintf "The operation timed out after %fsec" timeout.TotalSeconds)))
 
 
 
@@ -265,7 +266,7 @@ module AsyncFunc =
   let timeout (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<'b> =
     fun a -> async.Delay (fun () -> f a) |> Async.timeoutAfter t
 
-  let timeoutResult (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<Result<'b, TimeoutException>> =
+  let timeoutResult (t:TimeSpan) (f:'a -> Async<'b>) : 'a -> Async<Result<'b, TimeSpan>> =
     fun a -> async.Delay (fun () -> f a) |> Async.timeoutResult t 
   
 

--- a/src/kafunk/Utility/AsyncSeq.fs
+++ b/src/kafunk/Utility/AsyncSeq.fs
@@ -8,6 +8,9 @@ open System.Threading.Tasks
 /// Module with helper functions for working with asynchronous sequences
 module AsyncSeq =
 
+  let unfoldInfiniteAsync (s:'s) (f:'s -> Async<'a * 's>) : AsyncSeq<'a> =
+    AsyncSeq.unfoldAsync (f >> Async.map Some) s 
+
   let interleaveChoice (a:AsyncSeq<'a>) (b:AsyncSeq<'b>) : AsyncSeq<Choice<'a, 'b>> =
     AsyncSeq.interleave (a |> AsyncSeq.map Choice1Of2) (b |> AsyncSeq.map Choice2Of2)
 

--- a/src/kafunk/Utility/Faults.fs
+++ b/src/kafunk/Utility/Faults.fs
@@ -206,10 +206,10 @@ module Faults =
     let retryResultWarnList (p:RetryPolicy) (f:'a -> Async<Result<'b, 'e>>) : 'a -> Async<Result<'b * 'e list, 'e list>> =
       fun a -> async.Delay (fun () -> f a) |> retryAsyncResultWarnList p
 
-    let retryResultThrow (ex:'e -> exn) (m:Monoid<'e>) (p:RetryPolicy) (f:'a -> Async<Result<'b, 'e>>) : 'a -> Async<'b> =
+    let retryResultThrow (ex:'e -> #exn) (m:Monoid<'e>) (p:RetryPolicy) (f:'a -> Async<Result<'b, 'e>>) : 'a -> Async<'b> =
       fun a -> async.Delay (fun () -> f a) |> retryResultThrow ex m p
 
-    let retryResultThrowList (ex:'e list -> exn) (p:RetryPolicy) (f:'a -> Async<Result<'b, 'e>>) : 'a -> Async<'b> =
+    let retryResultThrowList (ex:'e list -> #exn) (p:RetryPolicy) (f:'a -> Async<Result<'b, 'e>>) : 'a -> Async<'b> =
       fun a -> async.Delay (fun () -> f a) |> retryResultThrowList ex p
     
     let doAfterError (g:'a * 'e -> unit) : ('a -> Async<Result<'b, 'e>>) -> ('a -> Async<Result<'b, 'e>>) =

--- a/src/kafunk/Utility/Faults.fs
+++ b/src/kafunk/Utility/Faults.fs
@@ -153,10 +153,12 @@ module Faults =
           return! loop (i + 1) e }
     loop 0 m.Zero
 
+  /// Retries an async computation using the specified retry policy until the shouldRetry condition returns false.
+  /// Returns None when shouldRetry returns false.
   let retryAsync (p:RetryPolicy) (shouldRetry:'a -> bool) (a:Async<'a>) : Async<'a option> =
     let a = a |> Async.map (fun a -> if shouldRetry a then Failure (Some a) else Success (Some a))
     retryAsyncResult 
-      Monoid.optionRight
+      Monoid.optionLast
       p 
       a
     |> Async.map (Result.codiag)

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -63,7 +63,7 @@ module Monoid =
 
   let inline merge (m:Monoid<_>) a b = m.Merge (a,b)
 
-  let monoid (z:'a) (m:'a -> 'a -> 'a) =
+  let inline monoid (z:'a) (m:'a -> 'a -> 'a) =
     { new Monoid<'a> with
         member __.Zero = z
         member __.Merge (a,b) = m a b }
@@ -79,6 +79,23 @@ module Monoid =
   
   let stringConcat (s:string) : Monoid<string> =
     monoid "" (fun a b -> a + s + b)
+
+  [<GeneralizableValue>]
+  let optionLeft<'a> : Monoid<'a option> =
+    monoid None (fun a _ -> a)
+
+  [<GeneralizableValue>]
+  let optionRight<'a> : Monoid<'a option> =
+    monoid None (fun _ b -> b)
+
+  [<GeneralizableValue>]
+  let optionMergeLeft<'a> : Monoid<'a option> =
+    monoid None (fun a b -> match a,b with Some _,_ -> a | None,b -> b)
+
+  [<GeneralizableValue>]
+  let optionMergeRight<'a> : Monoid<'a option> =
+    monoid None (fun a b -> match a,b with _,Some _ -> b | a,None -> a)
+    
 
 // --------------------------------------------------------------------------------------------------
 
@@ -170,6 +187,7 @@ module ResultEx =
 
   let inline Failure e : Result<'a, 'e> = Choice2Of2 e
 
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Result =
 
   let inline success a : Result<'a, 'e> = Choice1Of2 a
@@ -182,13 +200,38 @@ module Result =
   let inline mapError f (r:Result<'a, 'e>) : Result<'a, 'e2> =
      Choice.mapRight f r
 
+  let map2 (g:'e -> 'e -> 'e) (f:'a -> 'b -> 'c) (r1:Result<'a, 'e>) (r2:Result<'b, 'e>) : Result<'c, 'e> =
+    match r1, r2 with
+    | Success a, Success b -> Success (f a b)
+    | Failure e1, Failure e2 -> Failure (g e1 e2)
+    | Failure e1, _ -> Failure e1
+    | _, Failure e2 -> Failure e2
+
+  let tryFirst (r1:Result<'a, 'e>) (r2:Result<'a, 'e>) : Result<'a, 'e> =
+    match r1, r2 with
+    | Success r1, _ -> Success r1
+    | _, Success r2 -> Success r2
+    | Failure e1, _ -> Failure e1
+
+  let trySecond (r1:Result<'a, 'e>) (r2:Result<'a, 'e>) : Result<'a, 'e> =
+    match r1, r2 with
+    | _, Success r2 -> Success r2
+    | Success r1, _ -> Success r1    
+    | _, Failure e2 -> Failure e2
+
   let bind (f:'a -> Result<'b, 'e>) (r:Result<'a, 'e>) : Result<'b, 'e> =
     match r with
     | Choice1Of2 a -> f a
     | Choice2Of2 e -> Choice2Of2 e
  
-  let fold f g (r:Result<'a, 'e>) : 'b = 
+  let inline fold f g (r:Result<'a, 'e>) : 'b = 
     Choice.fold f g r
+
+  let trySuccess (r:Result<'a, 'e>) : 'a option =
+    fold Some (fun _ -> None) r
+
+  let inline codiag (r:Result<'a, 'a>) : 'a = 
+    fold id id r
 
   let traverse (f:'a -> Result<'b, 'e>) (xs:seq<'a>) : Result<'b[], 'e> =
     use en = xs.GetEnumerator()
@@ -213,6 +256,11 @@ module Result =
     match r with
     | Success a -> a
     | Failure e -> raise (f e)
+
+  let monoid (ma:Monoid<'a>) (me:Monoid<'e>) : Monoid<Result<'a, 'e>> =
+    Monoid.monoid 
+      (Failure me.Zero) 
+      (map2 (Monoid.merge me) (Monoid.merge ma))
 
 // --------------------------------------------------------------------------------------------------
 

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -80,20 +80,14 @@ module Monoid =
   let stringConcat (s:string) : Monoid<string> =
     monoid "" (fun a b -> a + s + b)
 
+  /// A monoid for 'a option returning the first non-None value.
   [<GeneralizableValue>]
-  let optionLeft<'a> : Monoid<'a option> =
-    monoid None (fun a _ -> a)
-
-  [<GeneralizableValue>]
-  let optionRight<'a> : Monoid<'a option> =
-    monoid None (fun _ b -> b)
-
-  [<GeneralizableValue>]
-  let optionMergeLeft<'a> : Monoid<'a option> =
+  let optionFirst<'a> : Monoid<'a option> =
     monoid None (fun a b -> match a,b with Some _,_ -> a | None,b -> b)
 
+  /// A monoid for 'a option returning the last non-None value.
   [<GeneralizableValue>]
-  let optionMergeRight<'a> : Monoid<'a option> =
+  let optionLast<'a> : Monoid<'a option> =
     monoid None (fun a b -> match a,b with _,Some _ -> b | a,None -> a)
     
 
@@ -256,11 +250,6 @@ module Result =
     match r with
     | Success a -> a
     | Failure e -> raise (f e)
-
-  let monoid (ma:Monoid<'a>) (me:Monoid<'e>) : Monoid<Result<'a, 'e>> =
-    Monoid.monoid 
-      (Failure me.Zero) 
-      (map2 (Monoid.merge me) (Monoid.merge ma))
 
 // --------------------------------------------------------------------------------------------------
 

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -18,7 +18,7 @@ module Prelude =
     try d.Dispose() finally ()
 
 
-[<AutoOpen>]  
+[<AutoOpen>]
 module TimeSpanEx =
   
   open System
@@ -273,6 +273,12 @@ module Result =
     | Failure e -> Failure (Choice2Of2 e)
     | Success (Success a) -> Success a
     | Success (Failure e) -> Failure (Choice1Of2 e)
+
+  let ofOptionMap (e:unit -> 'e) (o:'a option) : Result<'a, 'e> =
+    match o with Some a -> Success a | None -> Failure (e ())
+
+  let ofOption (o:'a option) : Result<'a, unit> =
+    match o with Some a -> Success a | None -> Failure ()
 
 // --------------------------------------------------------------------------------------------------
 

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -18,6 +18,23 @@ module Prelude =
     try d.Dispose() finally ()
 
 
+[<AutoOpen>]  
+module TimeSpanEx =
+  
+  open System
+
+  type TimeSpan with
+    static member FromMilliseconds (ms:int) =
+      TimeSpan.FromMilliseconds (float ms)
+    static member FromSeconds (sec:int) =
+      TimeSpan.FromSeconds (float sec)
+    static member Mutiply (s:TimeSpan) (x:int) =
+      let mutable s = s
+      for _ in [1..x] do
+        s <- s.Add s
+      s
+
+
 module Option =
   
   let getOr (defaultValue:'a) = function Some a -> a | None -> defaultValue
@@ -210,7 +227,7 @@ module Result =
   let trySecond (r1:Result<'a, 'e>) (r2:Result<'a, 'e>) : Result<'a, 'e> =
     match r1, r2 with
     | _, Success r2 -> Success r2
-    | Success r1, _ -> Success r1    
+    | Success r1, _ -> Success r1
     | _, Failure e2 -> Failure e2
 
   let bind (f:'a -> Result<'b, 'e>) (r:Result<'a, 'e>) : Result<'b, 'e> =
@@ -250,6 +267,12 @@ module Result =
     match r with
     | Success a -> a
     | Failure e -> raise (f e)
+
+  let join (r:Result<Result<'a, 'e1>, 'e2>) : Result<'a, Choice<'e1, 'e2>> =
+    match r with
+    | Failure e -> Failure (Choice2Of2 e)
+    | Success (Success a) -> Success a
+    | Success (Failure e) -> Failure (Choice1Of2 e)
 
 // --------------------------------------------------------------------------------------------------
 

--- a/src/kafunk/Utility/Resource.fs
+++ b/src/kafunk/Utility/Resource.fs
@@ -109,6 +109,7 @@ module Resource =
     member internal __.Inject<'a, 'b> (op:'r -> ('a -> Async<'b>)) : Async<'a -> Async<'b>> = async {
       let rec go a = async {
         let! ep = MVar.get cell
+        //let ep = MVar.getFastUnsafe cell |> Option.get
         try
           let! res = op ep.resource a |> Async.cancelWithToken ep.closed.Token
           match res with

--- a/src/kafunk/kafunk.fsproj
+++ b/src/kafunk/kafunk.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>kafunk</RootNamespace>
     <AssemblyName>Kafunk</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>kafunk</Name>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/kafunk/kafunk.fsproj
+++ b/src/kafunk/kafunk.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>kafunk</RootNamespace>
     <AssemblyName>Kafunk</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name>kafunk</Name>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/tests/kafunk.Tests/App.config
+++ b/tests/kafunk.Tests/App.config
@@ -1,11 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.3.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.3.1.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.5.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.78.3.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.259.3.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.3.1.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.47.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.78.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.259.4.0" newVersion="4.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
 </configuration>

--- a/tests/kafunk.Tests/App.config
+++ b/tests/kafunk.Tests/App.config
@@ -4,19 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.3.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.3.1.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.5.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.78.3.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.259.3.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.3.1.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.47.4.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.78.4.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.259.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="2.3.0.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="4.3.0.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="3.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="2.3.5.1" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="3.78.3.1" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="3.259.3.1" newVersion="4.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/kafunk.Tests/Async.fsx
+++ b/tests/kafunk.Tests/Async.fsx
@@ -1,0 +1,25 @@
+﻿#r "bin/release/fsharp.control.asyncseq.dll"
+#r "bin/release/kafunk.dll"
+#time "on"
+
+
+open Kafunk
+open System
+
+let N = 100000
+
+//let choose i = async {
+//  return! Async.choose2 (Async.Sleep 1) (Async.Sleep 1) }
+
+let choose i = async {
+  return! Async.choose (Async.empty) (Async.empty) }
+
+Seq.init N choose
+|> Async.ParallelThrottledIgnore Int32.MaxValue
+//|> Async.Parallel
+|> Async.RunSynchronously
+|> ignore
+
+
+// Real: 00:00:02.463, CPU: 00:00:04.531, GC gen0: 57, gen1: 54, gen2: 2
+// Real: 00:00:01.807, CPU: 00:00:03.156, GC gen0: 48, gen1: 43, gen2: 2

--- a/tests/kafunk.Tests/AsyncTests.fs
+++ b/tests/kafunk.Tests/AsyncTests.fs
@@ -2,15 +2,118 @@
 
 open Kafunk
 open NUnit.Framework
+open System.Threading
+open System.Threading.Tasks
 
 [<Test>]
-let ``should regard infinite timeouts as equal`` () =
+let ``Async.never should regard infinite timeouts as equal`` () =
   Assert.AreEqual (Async.never, Async.never)
 
 [<Test>]
-let ``should choose first to complete`` () =
-  for fastMs in [1..10] do
+let ``Async.choose should choose first to complete`` () =
+  for fastMs in [1..20] do
     let fast = Async.Sleep fastMs |> Async.map Choice1Of2
-    let slow = Async.Sleep (fastMs * 5) |> Async.map Choice2Of2
+    let slow = Async.Sleep (fastMs + 20) |> Async.map Choice2Of2
     let first = Async.choose fast slow
-    Assert.AreEqual (fast, fast)
+    Assert.AreEqual (fast, first)
+
+[<Test>]
+let ``MVar.updateAsync should execute update serially`` () =
+  let mv = MVar.create ()
+  
+  let calling = 1
+  let calls = 100
+
+  mv |> MVar.put calling |> Async.RunSynchronously |> ignore
+  
+  let st = ref 0
+
+  let update i = async {
+    do! Async.SwitchToThreadPool ()
+    return i + 1 }
+
+  let op calling = async {
+    let! i' =
+      mv 
+      |> MVar.updateAsync (fun i -> async {
+        if Interlocked.CompareExchange (st, 1, 0) <> 0 then
+          return failwith "overlapping execution detected"
+        let! r = 
+          if i = calling then update i
+          else async { return i }
+        if Interlocked.CompareExchange (st, 0, 1) <> 1 then
+          return failwith "overlapping execution detected"
+        return r })
+    return i' }
+
+  let actual = 
+    Async.Parallel (Seq.init calls (fun _ -> op calling))
+    |> Async.RunSynchronously
+    |> List.ofArray
+  
+  let expected = List.init calls (fun _ -> calling + 1)
+  
+  shouldEqual expected actual None
+
+
+[<Test>]
+let ``Async.withCancellation should cancel`` () =
+  
+  let cts = new CancellationTokenSource()
+  let cancelled = ref false
+
+  let comp = async {
+    let! ct = Async.CancellationToken
+    ct.Register (fun () -> cancelled := true) |> ignore
+    while true do
+      do! Async.Sleep 2 }
+
+  let cancellableComp = Async.cancelWithToken cts.Token comp
+
+  cts.CancelAfter 200
+
+  let expected = None
+  let actual = Async.RunSynchronously cancellableComp
+
+  shouldEqual expected actual None
+  shouldEqual true !cancelled None
+
+
+[<Test>]
+let ``Async.choose should respect ambient cancellation token`` () =
+  
+  let cancelled0 = ref false
+  let cancelled1 = ref false
+  let cancelled2 = ref false
+
+  let comp1 = async {
+    let! ct = Async.CancellationToken
+    ct.Register (fun () -> cancelled1 := true) |> ignore
+    while not (ct.IsCancellationRequested) do
+      () }
+
+  let comp2 = async {
+    let! ct = Async.CancellationToken
+    ct.Register (fun () -> cancelled2 := true) |> ignore
+    while not (ct.IsCancellationRequested) do
+      () }
+
+  let r = TaskCompletionSource<unit>()
+
+  let c = async {
+    let! ct = Async.CancellationToken
+    ct.Register (fun () -> cancelled0 := true) |> ignore
+    let! _ = Async.choose comp1 comp2
+    r.SetResult() }
+
+  let cts = new CancellationTokenSource()
+
+  Async.Start (c, cts.Token)
+
+  cts.CancelAfter 50
+
+  let completed = r.Task.Wait (200)
+
+  shouldEqual true !cancelled0 None
+  shouldEqual true !cancelled1 None
+  shouldEqual true !cancelled2 None

--- a/tests/kafunk.Tests/FaultsTests.fs
+++ b/tests/kafunk.Tests/FaultsTests.fs
@@ -54,7 +54,7 @@ let ``should retry with reevaluation`` () =
       else
         async.Return (Failure ())
 
-    let backoff = Backoff.constant 10 |> Backoff.maxAttempts attempts
+    let backoff = RetryPolicy.constant 10 |> RetryPolicy.maxAttempts attempts
 
     let sleepEcho =
       sleepEcho 
@@ -86,7 +86,7 @@ let ``should retry timeout with backoff and succeed`` () =
             do! Async.Sleep (int time.TotalMilliseconds * 2)
             return () }
 
-      let backoff = Backoff.constant 10 |> Backoff.maxAttempts attempts
+      let backoff = RetryPolicy.constant 10 |> RetryPolicy.maxAttempts attempts
 
       let sleepEcho =
         sleepEcho

--- a/tests/kafunk.Tests/Offsets.fsx
+++ b/tests/kafunk.Tests/Offsets.fsx
@@ -1,0 +1,22 @@
+﻿#r "bin/release/fsharp.control.asyncseq.dll"
+#r "bin/release/kafunk.dll"
+#time "on"
+
+open FSharp.Control
+open Kafunk
+
+let Log = Log.create __SOURCE_FILE__
+
+let host = ""
+let topic = ""
+
+let conn = Kafka.connHost host
+
+let offsets = 
+  Kafka.Composite.offsets conn topic [ Time.EarliestOffset ; Time.LatestOffset ] 1
+  |> Async.RunSynchronously
+
+for kvp in offsets do
+  for (tn,offsets) in kvp.Value.topics do
+    for p in offsets do
+      printfn "time=%i topic=%s partition=%i offsets=%A" kvp.Key tn p.partition p.offsets

--- a/tests/kafunk.Tests/kafunk.Tests.fsproj
+++ b/tests/kafunk.Tests/kafunk.Tests.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>kafunk.Tests</RootNamespace>
     <AssemblyName>Kafunk.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>kafunk.Tests</Name>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
@@ -77,6 +77,7 @@
     <None Include="Consumer.fsx" />
     <None Include="ProducerConsumer.fsx" />
     <None Include="Offsets.fsx" />
+    <None Include="Async.fsx" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/kafunk.Tests/kafunk.Tests.fsproj
+++ b/tests/kafunk.Tests/kafunk.Tests.fsproj
@@ -76,6 +76,7 @@
     <None Include="Fetch.fsx" />
     <None Include="Consumer.fsx" />
     <None Include="ProducerConsumer.fsx" />
+    <None Include="Offsets.fsx" />
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/kafunk.Tests/kafunk.Tests.fsproj
+++ b/tests/kafunk.Tests/kafunk.Tests.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>kafunk.Tests</RootNamespace>
     <AssemblyName>Kafunk.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name>kafunk.Tests</Name>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>


### PR DESCRIPTION
- Renamed `Backoff` to `RetryPolicy`
- Consumer end-of-topic polling configurable using `RetryPolicy`
- Consumer offsets can be committed explicitly (to allow manual reset of a consumer, for example)

