### PR TITLE
Consumer offset out of range action configuration

### DIFF
--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -364,7 +364,7 @@ type ChanConfig = {
       sendBufferSize = defaultArg sendBufferSize 8192
       connectTimeout = defaultArg connectTimeout (TimeSpan.FromSeconds 10)
       connectRetryPolicy = defaultArg connectRetryPolicy (RetryPolicy.constantMs 2000 |> RetryPolicy.maxAttempts 50)
-      requestTimeout = defaultArg requestTimeout (TimeSpan.FromSeconds 10)
+      requestTimeout = defaultArg requestTimeout (TimeSpan.FromSeconds 30)
       requestRetryPolicy = defaultArg requestRetryPolicy (RetryPolicy.constantMs 2000 |> RetryPolicy.maxAttempts 50)
     }
 

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -16,7 +16,7 @@ let group = argiDefault 3 "leo_test16"
 let go = async {
   let! conn = Kafka.connHostAsync host
   let consumerCfg = 
-    ConsumerConfig.create (group, [|topic|], initialFetchTime=Time.EarliestOffset, fetchBufferBytes=100000)
+    ConsumerConfig.create (group, [|topic|], initialFetchTime=Time.EarliestOffset, fetchBufferBytes=100000, outOfRangeAction=ConsumerOffsetOutOfRangeAction.ResumeConsumerWithFreshInitialFetchTime)
   return!
     Consumer.create conn consumerCfg
     |> Consumer.consume (fun tn p ms commit -> async {
@@ -26,7 +26,8 @@ let go = async {
         (ms.messages.Length)
         (ms.messages |> Seq.sumBy (fun (_,s,_) -> s))
         (if ms.messages.Length > 0 then ms.messages |> Seq.map (fun (o,_,_) -> o) |> Seq.min else -1L)
-      do! commit
+      //do! commit
+      Async.Start commit
     })
 }
 

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -16,7 +16,7 @@ let group = argiDefault 3 "leo_test16"
 let go = async {
   let! conn = Kafka.connHostAsync host
   let consumerCfg = 
-    ConsumerConfig.create (group, [|topic|], initialFetchTime=Time.EarliestOffset, fetchBufferBytes=100000, outOfRangeAction=ConsumerOffsetOutOfRangeAction.ResumeConsumerWithFreshInitialFetchTime)
+    ConsumerConfig.create (group, [|topic|], initialFetchTime=Time.EarliestOffset, fetchBufferBytes=100000 (*, outOfRangeAction=ConsumerOffsetOutOfRangeAction.ResumeConsumerWithFreshInitialFetchTime *))
   return!
     Consumer.create conn consumerCfg
     |> Consumer.consume (fun tn p ms commit -> async {
@@ -26,8 +26,7 @@ let go = async {
         (ms.messages.Length)
         (ms.messages |> Seq.sumBy (fun (_,s,_) -> s))
         (if ms.messages.Length > 0 then ms.messages |> Seq.map (fun (o,_,_) -> o) |> Seq.min else -1L)
-      //do! commit
-      Async.Start commit
+      do! commit
     })
 }
 


### PR DESCRIPTION
This PR exposes explicit configuration for the action to take when a consumer encounters a OffsetOutOfRange (error code 1) error. The error means that this offset is no longer stored by Kafka and typically occurs when messages at that offset have been cleaned up as part of a retention policy. The cleanup may outpace a consumer and so this can happen even if consumption starts at an appropriate offset.

The supported actions are:

```fsharp
/// The action to take when the consumer attempts to fetch an offset which is out of range.
/// This typically happens if the consumer is outpaced by the message cleanup process.
/// The default action is to halt consumption.
type ConsumerOffsetOutOfRangeAction =

  /// Halt the consumer, raising an exception.
  | HaltConsumer
  
  /// Halt the consumption of only the out of range partition.
  | HaltPartition

  /// Request a fresh set of offsets and resume consumption from the time
  /// configured as the initial fetch time for the consumer (earliest, or latest).
  | ResumeConsumerWithFreshInitialFetchTime
```

- `HaltConsumer` which is the safest option - it raises an exception and stops the consumer. If your application must not miss any messages, action will need to be taken out of band to restore lost messages before resuming consumption.

- `HaltPartition` stops consuming only the out of range partition, while continuing to consume others. This is a middle ground where you want to optimize the liveness of the system, without forgoing safety.

- `ResumeConsumerWithFreshInitialFetchTime` will request fresh offsets from Kafka and resume consumption from the offset time specified as the initial fetch time for the consumer (usually earliest/latest).



