### PR TITLE
Recover producer from error code 2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 0.0.5 - 30.12.2016
+
+* Auto recover producer from error code 2
+
 ### 0.0.4 - 29.12.2016
 
 * Consumer fetch request batching by broker

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -13,7 +13,7 @@ open Kafunk
 module Message =
 
   let create value key attrs =
-    Message(0, 0y, (defaultArg attrs 0y), (defaultArg key (Binary.empty)), value)
+    Message(0, 0y, (defaultArg attrs 0y), key, value)
 
   let ofBuffer data key =
     Message(0, 0y, 0y, (defaultArg  key (Binary.empty)), data)
@@ -521,7 +521,7 @@ module Chan =
       |> Resource.inject receive
 
     /// An unframed input stream.
-    let inputStream =
+    let receiveStream =
       Socket.receiveStreamFrom config.receiveBufferSize receive
       |> Framing.LengthPrefix.unframe
 
@@ -540,7 +540,7 @@ module Chan =
 
     let session =
       Session.requestReply
-        Session.corrId encode decode RequestMessage.awaitResponse inputStream send
+        Session.corrId encode decode RequestMessage.awaitResponse receiveStream send
 
     let send = 
       Session.send session

--- a/src/kafunk/Compression.fs
+++ b/src/kafunk/Compression.fs
@@ -9,7 +9,7 @@ module Compression =
 
   let private createMessage value compression =
     let attrs = compression |> sbyte |> Some
-    Message.create value None attrs
+    Message.create value Binary.empty attrs
 
   // The only thing that can be compressed is a MessageSet, not a single Message; this results in a message containing the compressed set
   let gzip messages =

--- a/src/kafunk/Utility/Resource.fs
+++ b/src/kafunk/Utility/Resource.fs
@@ -50,7 +50,7 @@ module Resource =
       let version = 
         match prevEpoch with
         | Some prev ->
-          Log.warn "closing_previous_resource_epoch|version=%i cancellation_requested=%b" prev.version prev.closed.IsCancellationRequested
+          //Log.warn "closing_previous_resource_epoch|version=%i cancellation_requested=%b" prev.version prev.closed.IsCancellationRequested
           prev.closed.Cancel()
           prev.version + 1
         | None ->
@@ -97,7 +97,7 @@ module Resource =
             do! Async.Sleep 2000
             return raise ex
         else
-          Log.warn "resource_recovery_already_requested|calling_version=%i current_version=%i" callingEpoch.version currentEpoch.version
+          Log.trace "resource_recovery_already_requested|calling_version=%i current_version=%i" callingEpoch.version currentEpoch.version
           return currentEpoch }
       cell |> MVar.updateAsync update
     

--- a/tests/kafunk.Tests/CompressionGzipTests.fs
+++ b/tests/kafunk.Tests/CompressionGzipTests.fs
@@ -11,8 +11,8 @@ let ``Message Compression with Gzip`` () =
     let messageBytes = [| 1uy; 2uy; 3uy; 4uy; 2uy; 6uy; 8uy |]
     let message2Bytes = [| 1uy; 2uy; 3uy; 2uy |]
 
-    let message = Message.create (Binary.ofArray messageBytes) None None
-    let message2 = Message.create (Binary.ofArray message2Bytes) None None
+    let message = Message.create (Binary.ofArray messageBytes) (Binary.empty) None
+    let message2 = Message.create (Binary.ofArray message2Bytes) (Binary.empty) None
     
     let inputMessage =
         Compression.gzip [message; message2]

--- a/tests/kafunk.Tests/Fetch.fsx
+++ b/tests/kafunk.Tests/Fetch.fsx
@@ -6,20 +6,21 @@ open FSharp.Control
 open Kafunk
 open System
 
-let topic = "test-topic"
 let host = "localhost:9092"
+let topic = "test-topic"
 let conn = Kafka.connHost host
 
-let offsetRes =
-  Kafka.Composite.topicOffsets conn (Time.EarliestOffset, 1) topic
+let offsets =
+  Offsets.offsets conn topic [] [Time.EarliestOffset] 1
   |> Async.RunSynchronously
+
+let offsetRes = Map.find Time.EarliestOffset offsets
 
 printfn "offset response topics=%i" offsetRes.topics.Length
 for (tn,ps) in offsetRes.topics do
   for p in ps do
     for o in p.offsets do
       printfn "topic=%s partition=%i offset=%i" tn p.partition o
-
 
 let (tn,ps) = offsetRes.topics.[0]
 


### PR DESCRIPTION
Under high producer load, Kafka can close the socket or emit error code 2 for a produce request. This PR handles this gracefully.