### PR TITLE
Consumer fetches offsets on start rather than join

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.0.6 - 30.12.2016
+
+* Fix bug in Async.choose
+* Consumer.commitOffsetsToTime
+* Consumer doesn't fetch offsets until its starts consuming
+
 ### 0.0.5 - 30.12.2016
 
 * Auto recover producer from error code 2

--- a/src/kafunk/Tcp.fs
+++ b/src/kafunk/Tcp.fs
@@ -328,7 +328,7 @@ type ReqRepSession<'a, 'b, 's> internal
       if rep.TrySetException (TimeoutException("The timeout expired before a response was received from the TCP stream.")) then
         let endTime = DateTime.UtcNow
         let elapsed = endTime - startTime
-        Log.warn "request_timed_out|correlation_id=%i in_flight_requests=%i state=%A start_time=%s end_time=%s elapsed_sec=%f" correlationId txs.Count state (startTime.ToString("s")) (endTime.ToString("s")) elapsed.TotalSeconds
+        Log.warn "request_cancelled|correlation_id=%i in_flight_requests=%i state=%A start_time=%s end_time=%s elapsed_sec=%f" correlationId txs.Count state (startTime.ToString("s")) (endTime.ToString("s")) elapsed.TotalSeconds
         let mutable token = Unchecked.defaultof<_>
         txs.TryRemove(correlationId, &token) |> ignore
     ct.Register (Action(cancel)) |> ignore
@@ -362,7 +362,7 @@ type ReqRepSession<'a, 'b, 's> internal
     //Log.trace "sending_request|correlation_id=%i bytes=%i" correlationId sessionData.Count
     let! _sent = send sessionData
     //Log.trace "request_sent|correlation_id=%i bytes=%i" correlationId sent
-    return! rep.Task |> Async.AwaitTask }
+    return! rep.Task |> Async.AwaitTaskCancellationAsError }
 
   interface IDisposable with
     member x.Dispose() = cts.Dispose()

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -173,7 +173,7 @@ module AsyncEx =
           let cts = CancellationTokenSource.CreateLinkedTokenSource ct
           let cancel () =
             cts.Cancel()
-            cts.Dispose()
+            // cts.Dispose()
           let ok a =
             if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
               ok a
@@ -189,39 +189,8 @@ module AsyncEx =
           Async.StartThreadPoolWithContinuations (a, ok, err, cnc, cts.Token)
           Async.StartThreadPoolWithContinuations (b, ok, err, cnc, cts.Token) }
 
-//    /// Creates an async computation which completes when any of the argument computations completes.
-//    /// The other computations are cancelled.
-//    static member select (xs:seq<Async<'a>>) : Async<'a> = async {
-//      let! ct = Async.CancellationToken
-//      return!
-//        Async.FromContinuations <| fun (ok,err,cnc) ->
-//          let state = ref 0
-//          let cts = CancellationTokenSource.CreateLinkedTokenSource ct
-//          let cancel () =
-//            cts.Cancel()
-//            cts.Dispose()
-//          let ok a =
-//            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
-//              ok a
-//              cancel ()
-//          let err (ex:exn) =
-//            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
-//              cancel ()
-//              err ex
-//          let cnc ex =
-//            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
-//              cancel ()
-//              cnc ex
-//          use en = xs.GetEnumerator ()
-//          while (not cts.IsCancellationRequested) && en.MoveNext () do
-//            Async.StartThreadPoolWithContinuations (en.Current, ok, err, cnc, cts.Token) }
-
     static member chooseChoice (a:Async<'a>) (b:Async<'b>) : Async<Choice<'a, 'b>> =
       Async.choose (a |> Async.map Choice1Of2) (b |> Async.map Choice2Of2)
-
-//    /// Returns an async computation which completes successfully when the cancellation is triggered.
-//    static member FromCancellationToken (ct:CancellationToken) : Async<unit> =
-//      Async.FromContinuations (fun (ok,_,_) -> ct.Register (Action(ok)) |> ignore)
 
     /// Cancels a computation and returns None if the CancellationToken is cancelled before the 
     /// computation completes.
@@ -238,12 +207,6 @@ module AsyncEx =
           tcs.SetException ex }
       Async.Start (a, cts.Token)
       return! tcs.Task |> Async.AwaitTask }
-
-      //Async.chooseChoice a (Async.FromCancellationToken ct) |> Async.map (Choice.tryLeft)
-
-//    static member cancelWithTokens (cts:CancellationToken[]) (a:Async<'a>) : Async<'a option> = async {
-//      use cts = CancellationTokenSource.CreateLinkedTokenSource (cts)
-//      return! Async.chooseChoice a (Async.FromCancellationToken cts.Token) |> Async.map (Choice.tryLeft) }
         
     static member Sleep (s:TimeSpan) : Async<unit> =
       Async.Sleep (int s.TotalMilliseconds)

--- a/src/kafunk/Utility/Log.fs
+++ b/src/kafunk/Utility/Log.fs
@@ -32,7 +32,7 @@ module Log =
   let private consume () =
     let bufferSize = 4096
     use stdout = Console.OpenStandardOutput (bufferSize)
-    use sw = new StreamWriter(stdout, Encoding.UTF8, bufferSize)
+    use sw = new StreamWriter(stdout, Encoding.Default, bufferSize)
     sw.AutoFlush <- true
     for line in buffer.GetConsumingEnumerable() do
       sw.WriteLine line

--- a/tests/kafunk.Tests/Async.fsx
+++ b/tests/kafunk.Tests/Async.fsx
@@ -5,11 +5,92 @@
 
 open Kafunk
 open System
+open System.Threading
 
-let N = 100000
+let N = 1000000
 
 //let choose i = async {
 //  return! Async.choose2 (Async.Sleep 1) (Async.Sleep 1) }
+
+[<AutoOpen>]
+module Ex =
+  
+  type Async with
+
+    /// Creates an async computation which completes when any of the argument computations completes.
+    /// The other computation is cancelled.
+    static member choose3 (a:Async<'a>) (b:Async<'a>) : Async<'a> = async {
+      let! ct = Async.CancellationToken
+      return!
+        Async.FromContinuations <| fun (ok,err,cnc) ->
+          let state = ref 0
+          let cts = CancellationTokenSource.CreateLinkedTokenSource ct
+          let cancel () = 
+            cts.Cancel ()
+            //cts.Dispose () // under load, this can cause slow downs and errors interllay in Async
+          let ok a =
+            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
+              ok a
+              cancel ()
+          let err (ex:exn) =
+            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
+              cancel ()
+              err ex
+          let cnc ex =
+            if (Interlocked.CompareExchange(state, 1, 0) = 0) then 
+              cancel ()
+              cnc ex
+          Async.StartThreadPoolWithContinuations (a, ok, err, cnc, cts.Token)
+          Async.StartThreadPoolWithContinuations (b, ok, err, cnc, cts.Token) }
+
+    static member choose2 a b : Async<'T> = async {
+      let! ct = Async.CancellationToken
+      return!
+        Async.FromContinuations (fun (cont, econt, ccont) ->
+          let result1 = ref (Choice1Of3())
+          let result2 = ref (Choice1Of3())
+          let handled = ref false
+          let lock f = lock handled f
+          let cts = CancellationTokenSource.CreateLinkedTokenSource ct
+
+          // Called when one of the workflows completes
+          let complete () = 
+            let op =
+              lock (fun () ->
+                // If we already handled result (and called continuation)
+                // then ignore. Otherwise, if the computation succeeds, then
+                // run the continuation and mark state as handled.
+                // Only throw if both workflows failed.
+                match !handled, !result1, !result2 with 
+                | true, _, _ -> ignore
+                | false, (Choice2Of3 value), _ 
+                | false, _, (Choice2Of3 value) -> 
+                    handled := true
+                    cts.Cancel ()
+                    //cts.Dispose ()
+                    (fun () -> cont value)
+                | false, Choice3Of3 e1, Choice3Of3 e2 -> 
+                    handled := true
+                    cts.Cancel () 
+                    //cts.Dispose ()
+                    (fun () -> econt (new AggregateException("Both clauses of a choice failed.", [| e1; e2 |])))
+                | false, Choice1Of3 _, Choice3Of3 _ 
+                | false, Choice3Of3 _, Choice1Of3 _ 
+                | false, Choice1Of3 _, Choice1Of3 _ -> ignore)
+            op()
+            cts.Cancel()
+
+          let run resCell a = async {
+            try
+              let! res = a
+              lock (fun () -> resCell := Choice2Of3 res)
+            with e ->
+              lock (fun () -> resCell := Choice3Of3 e)
+            complete () }
+
+          Async.Start (run result1 a, cts.Token)
+          Async.Start (run result2 b, cts.Token)) }
+
 
 let choose i = async {
   return! Async.choose (Async.empty) (Async.empty) }
@@ -21,5 +102,5 @@ Seq.init N choose
 |> ignore
 
 
-// Real: 00:00:02.463, CPU: 00:00:04.531, GC gen0: 57, gen1: 54, gen2: 2
-// Real: 00:00:01.807, CPU: 00:00:03.156, GC gen0: 48, gen1: 43, gen2: 2
+
+// Real: 00:00:02.676, CPU: 00:00:11.203, GC gen0: 520, gen1: 217, gen2: 1


### PR DESCRIPTION
This PR contains:

- Consumer fetches offsets when it starts consuming rather than when it joins the group
- A fix to a bug in Async.choose causing an error internal to Async (with respect to cancellation)