### PR TITLE
current state, fetch consumer offsets APIs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 0.0.12-alpha001 - 06.01.2017
+
+* Current consumer state API
+* Fetch consumer offsets API
+
 ### 0.0.11-alpha001 - 05.01.2017
 
 * Hide internal members

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -15,6 +15,8 @@ This example demonstrates a few uses of the Kafka client.
 *)
 
 #r "kafunk.dll"
+#r "FSharp.Control.AsyncSeq.dll"
+
 open Kafunk
 open System
 
@@ -52,6 +54,7 @@ for (p,offset) in prodRes.offsets do
   printfn "partition=%i offset=%i" p offset
 
 
+
 // consumer
 
 let consumerCfg = 
@@ -61,6 +64,7 @@ let consumer =
   Consumer.create conn consumerCfg
 
 // commit on every message set
+
 consumer
 |> Consumer.consume (fun ms -> async {
   printfn "topic=%s partition=%i" ms.topic ms.partition
@@ -69,26 +73,47 @@ consumer
 
 
 // commit periodically
+
 consumer
 |> Consumer.consumePeriodicCommit (TimeSpan.FromSeconds 10.0) (fun ms -> async {
   printfn "topic=%s partition=%i" ms.topic ms.partition })
 |> Async.RunSynchronously
 
 
-
-// commit consumer offsets
+// commit consumer offsets explicitly
 
 Consumer.commitOffsets consumer [| 0, 1L |]
 |> Async.RunSynchronously
 
-// commit consumer offsets to a relative time
+// commit consumer offsets explicitly to a relative time
 
 Consumer.commitOffsetsToTime consumer Time.EarliestOffset
 |> Async.RunSynchronously
 
 
+// get current consumer state
 
-// offset information
+let consumerState = 
+  Consumer.state consumer
+  |> Async.RunSynchronously
+
+printfn "generation_id=%i member_id=%s leader_id=%s partitions=%A" 
+  consumerState.generationId consumerState.memberId consumerState.leaderId consumerState.assignments
+
+
+
+// fetch offsets of a consumer group for a topic
+
+let consumerOffsets =
+  Consumer.fetchOffsetsByTopic conn "consumer-group" "absurd-topic"
+  |> Async.RunSynchronously
+
+for (p,o) in consumerOffsets do
+  printfn "partition=%i offset=%i" p o
+
+
+
+// fetch topic offset information
 
 let offsets = 
   Offsets.offsets conn "absurd-topic" [] [ Time.EarliestOffset ; Time.LatestOffset ] 1

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -34,7 +34,7 @@ let go = async {
       (ConsumerMessageSet.lastOffset ms)
       (ms.highWatermarkOffset)
       (ConsumerMessageSet.lag ms) }
-  do! consumer |> Consumer.consumePeriodicCommit (TimeSpan.FromSeconds 10) handle
+  do! consumer |> Consumer.consumePeriodicCommit (TimeSpan.FromSeconds 10.0) handle
 }
 
 Async.RunSynchronously go


### PR DESCRIPTION
This PR exposes APIs:

- Consumer.state - returns the current consumer state (generationId, memberId, leaderId, partition assignments)

- Consumer.fetchOffsetsByTopic - convenience API to gets a consumer group's committed offsets; does not require a group join.