### PR TITLE
Improve broker discovery and re-discovery

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.0.17-alpha001 - 17.01.2017
+
+* Discovery brokers by DNS when appropriate
+* Explicit channel failure and recovery contract
+
+
 ### 0.0.16-alpha001 - 09.01.2017
 
 * Fix bug in assignment strategy where all available metadate were used rather than that of subscribed topic

--- a/src/kafunk/AssemblyInfo.fs
+++ b/src/kafunk/AssemblyInfo.fs
@@ -4,10 +4,10 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("kafunk")>]
 [<assembly: AssemblyProductAttribute("kafunk")>]
 [<assembly: AssemblyDescriptionAttribute("F# client for Kafka")>]
-[<assembly: AssemblyVersionAttribute("0.0.15")>]
-[<assembly: AssemblyFileVersionAttribute("0.0.15")>]
+[<assembly: AssemblyVersionAttribute("0.0.16")>]
+[<assembly: AssemblyFileVersionAttribute("0.0.16")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.0.15"
-    let [<Literal>] InformationalVersion = "0.0.15"
+    let [<Literal>] Version = "0.0.16"
+    let [<Literal>] InformationalVersion = "0.0.16"

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -662,7 +662,8 @@ type KafkaConn internal (cfg:KafkaConfig) =
   member internal __.GetMetadata (topics:TopicName[]) = async {
     let state = __.GetState ()
     let! state' = getMetadata state topics
-    return state'.routes |> Routes.topicPartitions }
+    let topicPartitions = state'.routes |> Routes.topicPartitions
+    return topicPartitions |> Map.onlyKeys topics }
 
   member __.Close () =
     Log.info "closing_connection|client_id=%s" cfg.clientId

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -238,6 +238,12 @@ module Map =
   let addMany (kvps:('a * 'b) seq) (m:Map<'a, 'b>) : Map<'a, 'b> =
     kvps |> Seq.fold (fun m (k,v) -> Map.add k v m) m
 
+  let onlyKeys (ks:'a seq) (m:Map<'a, 'b>) : Map<'a, 'b> =
+    ks 
+    |> Seq.choose (fun k -> Map.tryFind k m |> Option.map (fun v -> k,v))
+    |> Map.ofSeq
+    
+
 // --------------------------------------------------------------------------------------------------
 
 

--- a/src/kafunk/Utility/Prelude.fs
+++ b/src/kafunk/Utility/Prelude.fs
@@ -192,6 +192,16 @@ module Seq =
       | Choice3Of3 c -> cx.Add(c)
     ax.ToArray(),bx.ToArray(),cx.ToArray()
 
+  let partitionChoices4 (s:seq<Choice<'a, 'b, 'c, 'd>>) : 'a[] * 'b[] * 'c[] * 'd[] =
+    let ax,bx,cx,dx = ResizeArray<_>(),ResizeArray<_>(),ResizeArray<_>(),ResizeArray<_>()
+    for c in s do
+      match c with
+      | Choice1Of4 a -> ax.Add(a)
+      | Choice2Of4 b -> bx.Add(b)
+      | Choice3Of4 c -> cx.Add(c)
+      | Choice4Of4 c -> dx.Add(c)
+    ax.ToArray(),bx.ToArray(),cx.ToArray(),dx.ToArray()
+
   let batch (batchSize:int) (s:seq<'a>) : seq<'a[]> =
       seq {
           use en = s.GetEnumerator()
@@ -259,8 +269,11 @@ module Result =
   let inline map f (r:Result<'a, 'e>) : Result<'b, 'e> = 
     Choice.mapLeft f r
 
-  let inline mapError f (r:Result<'a, 'e>) : Result<'a, 'e2> =
+  let inline mapError (f:'e -> 'e2) (r:Result<'a, 'e>) : Result<'a, 'e2> =
      Choice.mapRight f r
+
+  let inline tapError (f:'e -> unit) (r:Result<'a, 'e>) : Result<'a, 'e> =
+    mapError (fun e -> f e |> ignore ; e) r
 
   let map2 (g:'e -> 'e -> 'e) (f:'a -> 'b -> 'c) (r1:Result<'a, 'e>) (r2:Result<'b, 'e>) : Result<'c, 'e> =
     match r1, r2 with
@@ -449,3 +462,6 @@ module Observable =
       let batchSubs = batches.Subscribe(observer.OnNext)
 
       fun () -> sourceSubs.Dispose() ; batchSubs.Dispose() ; batchQueue.Dispose())
+  
+
+  

--- a/tests/kafunk.Tests/RoutingTests.fs
+++ b/tests/kafunk.Tests/RoutingTests.fs
@@ -11,7 +11,7 @@ let ``Routing.route should group offset requests by broker`` () =
   let routes = 
     Routes.ofBootstrap (EndPoint.ofIPAddressAndPort (IPAddress.Loopback, 9092))
     |> Routes.addBrokersAndTopicNodes 
-        [ (1,"127.0.0.1",9092) ] 
+        [ (1, EndPoint.parse ("127.0.0.1",9092)) ] 
         [ ("A",0,1) ; ("A",1,1) ]
 
   let offsetReq = OffsetRequest(-1, [| ("A", [| 0, Time.EarliestOffset, 1 |]) ; ("A", [| 1, Time.EarliestOffset, 1 |]) |])


### PR DESCRIPTION
This PR:

- Addresses: https://github.com/jet/kafunk/issues/93
- Makes failures of `Chan` recoverable by the connection, but not by the channel itself, explicit. This makes explicit the cases where cluster metadata must be rediscovered, and new channels established, before an operation is retried. This typically happens when brokers are rebalanced/restarted.