### PR TITLE
Producer buffering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.0.19-alpha001 - 25.01.2017
+
+* Producer buffering
+* Ensure cancellation propagated to consumer on group close
+* Logging improvements
+
 ### 0.0.18-alpha001 - 20.01.2017
 
 * Fix ConsumerMessageSet.lag measure

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -128,7 +128,7 @@ module internal Chan =
           NoDelay=not(config.useNagle),
           ExclusiveAddressUse=true,
           ReceiveBufferSize=config.receiveBufferSize,
-          SendBufferSize=config.receiveBufferSize)
+          SendBufferSize=config.sendBufferSize)
       return! Socket.connect connSocket ipep }
     
     let conn =

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -151,12 +151,11 @@ module internal Chan =
 
     let recovery (s:Socket, ver:int, _req:obj, ex:exn) = async {
       Log.warn "recovering_tcp_connection|client_id=%s remote_endpoint=%O version=%i error=%O" clientId (EndPoint.endpoint ep) ver ex
-      tryDispose s
-      return Resource.Recovery.Recreate }
+      tryDispose s }
 
     let! socketAgent = 
       Resource.recoverableRecreate 
-        (conn ep)
+        (fun _ -> conn ep)
         recovery
 
     let! send =

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -215,11 +215,11 @@ module internal Chan =
         | Success _ -> Failure (Choice1Of2 ())
         | Failure e -> Failure (Choice2Of2 e))
       |> AsyncFunc.doBeforeAfter
-          (fun req -> Log.trace "sending_request|request=%A" (RequestMessage.Print req))
+          (fun req -> Log.trace "sending_request|request=%s" (RequestMessage.Print req))
           (fun (req,res) -> 
             match res with
             | Success res -> 
-              Log.trace "received_response|response=%A" (ResponseMessage.Print res)
+              Log.trace "received_response|response=%s" (ResponseMessage.Print res)
             | Failure (Choice1Of2 ()) ->
               Log.warn "request_timed_out|ep=%O request=%s timeout=%O" ep (RequestMessage.Print req) config.requestTimeout
             | Failure (Choice2Of2 e) ->

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -476,7 +476,7 @@ module Consumer =
 
   /// Returns an async sequence corresponding to generations, where each generation
   /// is paired with the set of assigned fetch streams.
-  let internal generations (consumer:Consumer) =
+  let generations (consumer:Consumer) =
 
     let cfg = consumer.config
     let topic = cfg.topic

--- a/src/kafunk/Helpers.fs
+++ b/src/kafunk/Helpers.fs
@@ -127,6 +127,9 @@ module internal Printers =
     let sb = StringBuilder()
     concatMapSbDo sb s f sep
     sb.ToString()
+
+  let partitions (os:seq<Partition>) =
+    concatMapSb os (fun sb (p) -> sb.AppendFormat("[partition={0}]", p)) " ; "
     
   let partitionOffsetPairs (os:seq<Partition * Offset>) =
     concatMapSb os (fun sb (p,o) -> sb.AppendFormat("[partition={0} offset={1}]", p, o)) " ; "

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -659,6 +659,11 @@ type KafkaConn internal (cfg:KafkaConfig) =
     let state = __.GetState ()
     return! getGroupCoordinator state groupId }
 
+  member internal __.GetMetadataState (topics:TopicName[]) = async {
+    let state = __.GetState ()
+    let! state' = getMetadata state topics
+    return state' }
+
   member internal __.GetMetadata (topics:TopicName[]) = async {
     let state = __.GetState ()
     let! state' = getMetadata state topics

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -438,7 +438,7 @@ type internal ConnState = {
 
 /// An exception used to wrap failures which are to be escalated.
 type EscalationException (errorCode:ErrorCode, req:RequestMessage, res:ResponseMessage, msg:string) =
-  inherit Exception (sprintf "Kafka exception|error_code=%i request=%A response=%A message=%s" errorCode (RequestMessage.Print req) (ResponseMessage.Print res) msg)
+  inherit Exception (sprintf "Kafka exception|error_code=%i request=%s response=%s message=%s" errorCode (RequestMessage.Print req) (ResponseMessage.Print res) msg)
 
 /// A connection to a Kafka cluster.
 /// This is a stateful object which maintains request/reply sessions with brokers.
@@ -601,7 +601,7 @@ type KafkaConn internal (cfg:KafkaConfig) =
         return! sendHost requestRoutes.[0]
 
     | Failure (MissingTopicRoute topic) ->
-      Log.warn "missing_topic_partition_route|topic=%s request=%A" topic req
+      Log.warn "missing_topic_partition_route|topic=%s request=%s" topic (RequestMessage.Print req)
       let! state' = getMetadata state [|topic|]
       return! send state' req
 

--- a/src/kafunk/Tcp.fs
+++ b/src/kafunk/Tcp.fs
@@ -323,7 +323,7 @@ type ReqRepSession<'a, 'b, 's> internal
         Log.error "response_decode_exception|correlation_id=%i error=%O payload=%s" correlationId ex (Binary.toString sessionData.payload)
         reply.TrySetException ex |> ignore
     else
-      Log.error "received_orphaned_response|correlation_id=%i in_flight_requests=%i" correlationId txs.Count
+      Log.warn "received_orphaned_response|correlation_id=%i in_flight_requests=%i" correlationId txs.Count
 
   let mux (ct:CancellationToken) (req:'a) =
     let startTime = DateTime.UtcNow

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -109,6 +109,16 @@ type Async with
         do! comp
         return raise ex }
 
+  static member tryFinnallyWithAsync (a:Async<'a>) (comp:Async<unit>) (err:exn -> Async<'a>) : Async<'a> =
+    async {
+      try
+        let! a = a
+        do! comp
+        return a
+      with ex ->
+        do! comp
+        return! err ex }
+
   static member tryFinally (compensation:unit -> unit) (a:Async<'a>) : Async<'a> =
     async.TryFinally(a, compensation)
 

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -54,6 +54,13 @@ module IVar =
   let inline get (i:IVar<'a>) : Async<'a> = 
     i.Task |> Async.AwaitTask
 
+  /// Returns a cancellation token which is cancelled when the IVar is set.
+  let inline toCancellationToken (i:IVar<_>) =
+    let cts = new CancellationTokenSource ()
+    i.Task.ContinueWith (fun (t:Task<_>) -> cts.Cancel ()) |> ignore
+    cts.Token
+    
+
 
 
 
@@ -243,6 +250,22 @@ type Async with
 
   static member chooseChoice (a:Async<'a>) (b:Async<'b>) : Async<Choice<'a, 'b>> =
     Async.choose (a |> Async.map Choice1Of2) (b |> Async.map Choice2Of2)
+
+  /// Cancels a computation and returns None if the CancellationToken is cancelled before the 
+  /// computation completes.
+  static member cancelTokenWith (ct:CancellationToken) (f:unit -> 'a) (a:Async<'a>) : Async<'a> = async {
+    let! ct2 = Async.CancellationToken
+    use cts = CancellationTokenSource.CreateLinkedTokenSource (ct, ct2)
+    let tcs = new TaskCompletionSource<'a>()
+    use _reg = cts.Token.Register (fun () -> tcs.SetResult (f ()))
+    let a = async {
+      try
+        let! a = a
+        tcs.SetResult a
+      with ex ->
+        tcs.SetException ex }
+    Async.Start (a, cts.Token)
+    return! tcs.Task |> Async.AwaitTask }
 
   /// Cancels a computation and returns None if the CancellationToken is cancelled before the 
   /// computation completes.

--- a/src/kafunk/Utility/Resource.fs
+++ b/src/kafunk/Utility/Resource.fs
@@ -18,151 +18,155 @@ and ResourceErrorAction<'a, 'e> =
   /// Recover the resource and retry the operation.
   | RecoverRetry of 'e
 
+  /// Retry the operation.
+  | Retry
+
+
+type internal ResourceEpoch<'r> = {
+  resource : 'r
+  closed : CancellationTokenSource
+  version : int
+}
+
+type Resource<'r> internal (create:CancellationToken -> Async<'r>, handle:('r * int * obj * exn) -> Async<unit>) =
+      
+  let Log = Log.create "Resource"
+    
+  let cell : MVar<ResourceEpoch<'r>> = MVar.create ()
+   
+  let create (prevEpoch:ResourceEpoch<'r> option) = async {
+    let closed = new CancellationTokenSource()
+    let version = 
+      match prevEpoch with
+      | Some prev ->
+        prev.closed.Cancel()
+        prev.version + 1
+      | None ->
+        0
+    let! res = create closed.Token |> Async.Catch
+    match res with
+    | Success r ->
+      return { resource = r ; closed = closed ; version = version }
+    | Failure e ->
+      return raise e }
+
+  let recover (req:obj) (ex:exn) (callingEpoch:ResourceEpoch<'r>) = async {
+    do! handle (callingEpoch.resource, callingEpoch.version, req, ex)
+    let! ep' = create (Some callingEpoch)
+    return ep' }
+
+  member internal __.Get () =
+    MVar.get cell |> Async.map (fun ep -> ep.resource)
+
+  member internal __.Create () = async {
+    return! cell |> MVar.putOrUpdateAsync create }
+
+  member internal __.TryGetVersion () =
+    MVar.getFastUnsafe cell |> Option.map (fun e -> e.version)
+
+  member private __.Recover (callingEpoch:ResourceEpoch<'r>, req:obj, ex:exn) =
+    let update currentEpoch = async {
+      if currentEpoch.version = callingEpoch.version then
+        try
+          let! ep2 = recover req ex callingEpoch
+          return ep2
+        with ex ->
+          Log.error "recovery_failed|error=%O" ex
+          do! Async.Sleep 2000
+          return raise ex
+      else
+        Log.trace "resource_recovery_already_requested|calling_version=%i current_version=%i" callingEpoch.version currentEpoch.version
+        return currentEpoch }
+    cell |> MVar.updateAsync update
+    
+  member internal __.Timeout<'a, 'b> (op:'r -> ('a -> Async<'b>)) : 'a -> Async<'b option> =
+    fun a -> async {
+      let! ep = MVar.get cell
+      return! op ep.resource a |> Async.cancelWithToken ep.closed.Token }
+
+  member internal __.InjectResult<'a, 'b> (op:'r -> ('a -> Async<Result<'b, ResourceErrorAction<'b, exn>>>), rp:RetryPolicy) : 'a -> Async<'b> =
+    let rec go rs a = async {
+      let! ep = MVar.get cell
+      let! b = op ep.resource a
+      match b with
+      | Success b -> 
+        return b
+      | Failure (RecoverResume (ex,b)) ->
+        let! _ = __.Recover (ep, a, ex)
+        return b
+      | Failure (RecoverRetry ex) ->
+        let! _ = __.Recover (ep, a, ex)
+        let! rs = RetryPolicy.awaitNext rp rs
+        match rs with
+        | None ->
+          return raise ex
+        | Some (_,rs) ->
+          return! go rs a
+      | Failure (Retry) ->
+        let! rs = RetryPolicy.awaitNext rp rs
+        match rs with
+        | None ->
+          return raise (exn())
+        | Some (_,rs) ->
+          return! go rs a }
+    go RetryPolicy.initState
+        
+  member internal __.InjectResult<'a, 'b> (op:'r -> ('a -> Async<ResourceResult<'b, exn>>)) : Async<'a -> Async<'b>> = async {
+    let rec go a = async {
+      let! ep = MVar.get cell
+      let! res = op ep.resource a
+      match res with
+      | Success b -> 
+        return b
+      | Failure (RecoverResume (ex,b)) ->
+        let! _ = __.Recover (ep, a, ex)
+        return b
+      | Failure (RecoverRetry ex) ->
+        let! _ = __.Recover (ep, a, ex)
+        return! go a
+      | Failure (Retry) ->
+        return! go a }
+    return go }
+
+  member internal __.Inject<'a, 'b> (op:'r -> ('a -> Async<'b>)) : Async<'a -> Async<'b>> = async {
+    let rec go a = async {
+      let! ep = MVar.get cell
+      try
+        return! op ep.resource a
+      with ex ->
+        let! _ = __.Recover (ep, box a, ex)
+        return! go a }
+    return go }
+
+  interface IDisposable with
+    member __.Dispose () = ()
+
 // operations on resource monitors.
 module Resource =
-
-  /// Resource recovery action
-  type Recovery =
-      
-    /// The resource should be re-created.
-    | Recreate
-
-    /// The error should be escalated, notifying dependent
-    /// resources.
-    | Escalate
-
-
-  type Epoch<'r> = {
-    resource : 'r
-    closed : CancellationTokenSource
-    version : int
-  }
-     
-  /// <summary>
-  /// Recoverable resource supporting the creation recoverable operations.
-  /// - create - used to create the resource initially and upon recovery. Overlapped inocations
-  ///   of this function are queued and given the instance being created when creation is complete.
-  /// - handle - called when an exception is raised by an resource-dependent computation created
-  ///   using this resrouce. If this function throws an exception, it is escalated.
-  /// </summary>
-  /// <notes>
-  /// A resource is an entity which undergoes state changes and is used by operations.
-  /// Resources can form supervision hierarchy through a message passing and reaction system.
-  /// Supervision hierarchies can be used to re-cycle chains of dependent resources.
-  /// </notes>
-  type Resource<'r> internal (create:Async<'r>, handle:('r * int * obj * exn) -> Async<Recovery>) =
-      
-    let Log = Log.create "Resource"
     
-    let cell : MVar<Epoch<'r>> = MVar.create ()
-   
-    let create (prevEpoch:Epoch<'r> option) = async {
-      let version = 
-        match prevEpoch with
-        | Some prev ->
-          //Log.warn "closing_previous_resource_epoch|version=%i cancellation_requested=%b" prev.version prev.closed.IsCancellationRequested
-          prev.closed.Cancel()
-          prev.version + 1
-        | None ->
-          0
-      let! r = create |> Async.Catch
-      match r with
-      | Success r ->
-        //Log.info "created_resource|version=%i" version
-        return { resource = r ; closed = new CancellationTokenSource() ; version = version }
-      | Failure e ->
-        //Log.error "resource_creation_failed|error=%O" e
-        return raise e }
-
-    let recover (req:obj) (ex:exn) (ep:Epoch<'r>) = async {
-      let! recovery = handle (ep.resource, ep.version, req, ex)
-      match recovery with
-      | Escalate ->
-        return raise ex
-      | Recreate ->
-        let! ep' = create (Some ep)
-        return ep' }
-
-    member internal __.Get () =
-      MVar.get cell |> Async.map (fun ep -> ep.resource)
-
-    member internal __.Create () = async {
-      return! cell |> MVar.putOrUpdateAsync create }
-
-    member internal __.TryGetVersion () =
-      MVar.getFastUnsafe cell |> Option.map (fun e -> e.version)
-
-    member private __.Recover (callingEpoch:Epoch<'r>, req:obj, ex:exn) =
-      let update currentEpoch = async {
-        if currentEpoch.version = callingEpoch.version then
-          try
-            let! ep2 = recover req ex callingEpoch
-            return ep2
-          with ex ->
-            Log.error "recovery_failed|error=%O" ex
-            do! Async.Sleep 2000
-            return raise ex
-        else
-          Log.trace "resource_recovery_already_requested|calling_version=%i current_version=%i" callingEpoch.version currentEpoch.version
-          return currentEpoch }
-      cell |> MVar.updateAsync update
-    
-    member internal __.Timeout<'a, 'b> (op:'r -> ('a -> Async<'b>)) : 'a -> Async<'b option> =
-      fun a -> async {
-        let! ep = MVar.get cell
-        return! op ep.resource a |> Async.cancelWithToken ep.closed.Token }
-        
-    member internal __.InjectResult<'a, 'b> (op:'r -> ('a -> Async<ResourceResult<'b, exn>>)) : Async<'a -> Async<'b>> = async {
-      let rec go a = async {
-        let! ep = MVar.get cell
-        let! res = op ep.resource a
-        match res with
-        | Success b -> 
-          return b
-        | Failure (RecoverResume (ex,b)) ->
-          let! _ = __.Recover (ep, a, ex)
-          return b
-        | Failure (RecoverRetry ex) ->
-          let! _ = __.Recover (ep, a, ex)
-          return! go a }
-      return go }
-
-    member internal __.Inject<'a, 'b> (op:'r -> ('a -> Async<'b>)) : Async<'a -> Async<'b>> = async {
-      let rec go a = async {
-        let! ep = MVar.get cell
-        try
-          return! op ep.resource a
-//          let! res = op ep.resource a |> Async.cancelWithToken ep.closed.Token
-//          match res with
-//          | Some res ->
-//            return res
-//          | None ->
-//            return! go a
-        with ex ->
-          let! _ = __.Recover (ep, box a, ex)
-          return! go a }
-      return go }
-
-    interface IDisposable with
-      member __.Dispose () = ()
-    
-  let recoverableRecreate (create:Async<'r>) (handleError:('r * int * obj * exn) -> Async<Recovery>) = async {
+  let recoverableRecreate (create:CancellationToken -> Async<'r>) (handleError:('r * int * obj * exn) -> Async<unit>) = async {
     let r = new Resource<_>(create, handleError)
     let! _ = r.Create()
     return r }
-
-  /// Injects a resource into a resource-dependent computation.
-  /// Returns a computation with the resource injected.
-  /// Exceptions raised by the computation are caught and recovered using the recovery strategy associated
-  /// with the resource.
+  
   let inject (op:'r -> ('a -> Async<'b>)) (r:Resource<'r>) : Async<'a -> Async<'b>> =
     r.Inject op
 
   let injectResult (op:'r -> ('a -> Async<ResourceResult<'b, exn>>)) (r:Resource<'r>) : Async<'a -> Async<'b>> =
     r.InjectResult op
 
+  let injectWithRecovery (r:Resource<'r>) (rp:RetryPolicy) (op:'r -> ('a -> Async<Result<'b, ResourceErrorAction<'b, exn>>>)) : 'a -> Async<'b> =
+    r.InjectResult (op, rp)
+
+  let injectWithRecovery2 (r:Resource<'r>) (recovery:'b -> ResourceErrorAction<'b, exn> option) (rp:RetryPolicy) (op:'r -> ('a -> Async<'b>)) : 'a -> Async<'b> =
+    let op r a = op r a |> Async.map (fun b -> match recovery b with Some r -> Failure r | None -> Success b)
+    r.InjectResult (op, rp)
+
   let timeout (r:Resource<'r>) : ('r -> ('a -> Async<'b>)) -> ('a -> Async<'b option>) =
     r.Timeout
 
   let timeoutIndep (r:Resource<'r>) (f:'a -> Async<'b>) : 'a -> Async<'b option> =
     r.Timeout (fun _ -> f)
+
+  let get (r:Resource<'r>) : Async<'r> =
+    r.Get ()

--- a/src/kafunk/kafunk.fsproj
+++ b/src/kafunk/kafunk.fsproj
@@ -69,9 +69,9 @@
     <Compile Include="Utility\Async.fs" />
     <Compile Include="Utility\MVar.fs" />
     <Compile Include="Utility\BoundedMb.fs" />
-    <Compile Include="Utility\Resource.fs" />
     <Compile Include="Utility\AsyncSeq.fs" />
     <Compile Include="Utility\Faults.fs" />
+    <Compile Include="Utility\Resource.fs" />
     <Compile Include="Tcp.fs" />
     <Compile Include="Protocol.fs" />
     <Compile Include="Helpers.fs" />

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -47,9 +47,11 @@ let go = async {
       (ms.highWatermarkOffset)
       (ConsumerMessageSet.lag ms) }
 
+  use counter = Metrics.counter Log 5000
+
   let handle = 
     handle
-    |> Metrics.throughputAsync2 Log 5000 (fun (_,ms,_) -> ms.messageSet.messages.Length)
+    |> Metrics.throughputAsync2To counter (fun (_,ms,_) -> ms.messageSet.messages.Length)
 
   do! consumer |> Consumer.consumePeriodicCommit (TimeSpan.FromSeconds 10.0) handle
 }

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -32,11 +32,12 @@ let go = async {
       fetchMaxBytes = 200000,
       fetchBufferSize= 2,
       outOfRangeAction = ConsumerOffsetOutOfRangeAction.ResumeConsumerWithFreshInitialFetchTime,
-      sessionTimeout = 30000)
+      sessionTimeout = 10000)
   let! consumer = 
     Consumer.createAsync conn consumerConfig
   
   let handle (s:GroupMemberState) (ms:ConsumerMessageSet) = async {
+    use! _cnc = Async.OnCancel (fun () -> Log.warn "cancelling_handler")
     Log.trace "consuming_message_set|topic=%s partition=%i count=%i size=%i first_offset=%i last_offset=%i high_watermark_offset=%i lag=%i"
       ms.topic
       ms.partition
@@ -45,7 +46,8 @@ let go = async {
       (ConsumerMessageSet.firstOffset ms)
       (ConsumerMessageSet.lastOffset ms)
       (ms.highWatermarkOffset)
-      (ConsumerMessageSet.lag ms) }
+      (ConsumerMessageSet.lag ms)
+    do! Async.Sleep 30000 }
 
   use counter = Metrics.counter Log 5000
 

--- a/tests/kafunk.Tests/Metrics.fs
+++ b/tests/kafunk.Tests/Metrics.fs
@@ -1,0 +1,204 @@
+﻿namespace Kafunk
+
+open Kafunk
+open System
+open System.Threading
+open System.Collections
+open System.Collections.Generic
+open System.Collections.Concurrent
+open System.Diagnostics
+
+// *** WARNING ***: PLEASE DON'T LOOK AT THIS CODE
+
+module private Comparer =
+
+  let rev (c:IComparer<'a>) : IComparer<'a> =
+    { new IComparer<'a> with member __.Compare(x, y) = c.Compare(y, x) }
+
+
+type internal SortedBag<'a>(?c:IComparer<'a>) =
+  let comp = defaultArg c (Comparer<_>.Default :> IComparer<_>)
+  let list = new List<'a>()
+  member __.Item i = list.[i]
+  member __.Count = list.Count
+  member __.Add (a) =
+    let mutable i = list.BinarySearch(a, comp)
+    if i < 0 then i <- ~~~i
+    list.Insert(i, a)
+    i
+  member __.AddRange xs =
+    for x in xs do
+      __.Add x |> ignore
+  member __.Clear () = 
+    list.Clear()
+  member __.RemoveAt index =
+    list.RemoveAt index
+  member __.RemoveRange (index,count) =
+    list.RemoveRange (index,count)
+  member __.RemoveUpToInclusive (a:'a) =
+    let mutable i = list.BinarySearch(a, comp)
+    if i >= 0 then 
+      list.RemoveRange(0, i + 1)
+  interface IEnumerable with
+    member __.GetEnumerator() = list.GetEnumerator() :> IEnumerator
+  interface IEnumerable<'a> with
+    member __.GetEnumerator() = list.GetEnumerator() :> IEnumerator<'a>
+
+
+module private Util =
+
+  let inline getQuantile (percentile:float) (ms:SortedBag<_>) =
+    let i = int (Math.Ceiling(float ms.Count * percentile)) - 1
+    if i >= 0 && i < ms.Count then ms.[i]
+    else Unchecked.defaultof<_>
+
+  let inline write (log:Logger option) : string * [<ParamArray>]obj[] -> unit =
+    match log with
+    | Some log -> fun (msg,args) -> log.info "%s" msg
+    | None -> Console.WriteLine
+
+
+
+/// Measures averages, max and percentiles.
+type TimedCounter internal (?log:Logger, ?periodMs:float) =
+
+  let periodMs = defaultArg periodMs 1000.0
+  let periodSs = periodMs / 1000.0
+  let periodDenom = periodMs * periodSs
+
+  let mutable count = 0
+  let mutable tickCount = 0
+  let [<VolatileField>] mutable lastCnt = 0
+  let [<VolatileField>] mutable rateSum = 0.0
+  let rates = new SortedBag<float>(Comparer.rev Comparer<_>.Default)
+
+  let write : string * [<ParamArray>]obj[] -> unit =
+    match log with
+    | Some log -> fun (msg,args) -> log.info "%s" (String.Format(msg,args))
+    | None -> Console.WriteLine
+
+  let cb _ =
+    let count = count
+    if count = 0 then ()
+    else
+      let ticks = Interlocked.Increment &tickCount
+      let delta = count - lastCnt
+      lastCnt <- count
+      let rateSec = (float delta) / periodDenom
+
+      rates.Add rateSec |> ignore
+
+      let percentile50 = rates |> Util.getQuantile 0.5
+      let percentile90 = rates |> Util.getQuantile 0.9
+      let percentile99 = rates |> Util.getQuantile 0.99
+      let max = rates.[0]
+
+      let rateSum' = rateSum + rateSec
+      rateSum <- rateSum'
+      let avgRate = rateSum' / (float ticks)
+
+      write(
+        "last_sec={0,-10} | avg_sec={1,-10} | tp50_sec={2,-10} | tp90_sec={3,-10} | tp99_sec={4,-10} | max_sec={5,-10} | count={6,-10}",
+        [|
+          Math.Round(rateSec * periodMs, 0)
+          Math.Round(avgRate * periodMs, 0)
+          Math.Round(percentile50 * periodMs, 0)
+          Math.Round(percentile90 * periodMs, 0)
+          Math.Round(percentile99 * periodMs, 0)
+          Math.Round(max * periodMs, 0)
+          count
+        |])
+
+  let timer = new Timer(cb, null, 0, int periodMs)
+
+  member __.CountMany (cnt) =
+    Interlocked.Add(&count, cnt) |> ignore
+
+  member inline x.Count () = x.CountMany 1
+
+  member __.Stop () = timer.Dispose()
+
+  interface IDisposable with
+    member x.Dispose() = x.Stop()
+
+
+/// Measures averages, max and percentiles.
+type IntHistogram internal (?log:Logger, ?periodMs:float) =
+  let periodMs = defaultArg periodMs 1000.0
+  let write = Util.write log
+  let mutable count = 0
+  let mutable sum = 0
+  let rates = new SortedBag<int>(Comparer.rev Comparer<_>.Default)
+  let queue = new BlockingCollection<_>()
+  let consume (_:obj) =
+    use queue = queue
+    queue.GetConsumingEnumerable()
+    |> Seq.iter (fun x ->
+      rates.Add x |> ignore
+      Interlocked.Increment(&count) |> ignore
+      Interlocked.Add(&sum, x) |> ignore)
+  do (new Thread(ThreadStart(consume), IsBackground=true)).Start()
+  let emit (_:obj) =
+    let count = count
+    if count > 0 && rates.Count > 0 then
+      let tp50 = rates |> Util.getQuantile 0.50 |> float
+      let tp90 = rates |> Util.getQuantile 0.10 |> float
+      let tp99 = rates |> Util.getQuantile 0.01 |> float
+      let max = rates.[0] |> float
+      let min = rates.[rates.Count - 1] |> float
+      let count = float count
+      let avg = (float sum) / count
+      write(
+        "avg={0,-10} | tp50={1,-10} | tp90={2,-10} | tp99={3,-10} | min={4,-10} | max={5,-10} | count={6,-10}",
+        [| Math.Round(avg, 0) ; Math.Round(tp50, 0) ; Math.Round(tp90, 0) ; Math.Round(tp99, 0) ; Math.Round(min, 0) ; Math.Round(max, 0) ; Math.Round(count, 0) |])
+
+  let timer = new Timer(emit, null, 0, int periodMs)
+  
+  member __.Record (x:int) =
+    queue.Add x
+
+  member __.Stop () =
+    timer.Dispose()
+    queue.CompleteAdding()
+
+  interface IDisposable with
+    member x.Dispose() = x.Stop()
+
+[<Compile(Module)>]
+module Metrics =
+
+  let throughputAsyncTo (tc:TimedCounter) (count:'a * 'b -> int) (f:'a -> Async<'b>) : 'a -> Async<'b> =
+    fun a -> async {
+      let! b = f a
+      tc.CountMany (count (a,b))
+      return b }
+
+  let throughputAsync2To (tc:TimedCounter) (count:'a * 'b * 'c -> int) (f:'a -> 'b -> Async<'c>) : 'a -> 'b -> Async<'c> =
+    fun a b -> async {
+      let! c = f a b
+      tc.CountMany (count (a,b,c))
+      return c }
+  
+  let throughputAsync (log:Logger) (periodMs:int) (count:'a * 'b -> int) (f:'a -> Async<'b>) : 'a -> Async<'b> =
+    let tc = new TimedCounter(log, float periodMs)
+    throughputAsyncTo tc count f
+
+  let throughputAsync2 (log:Logger) (periodMs:int) (count:'a * 'b * 'c -> int) (f:'a -> 'b -> Async<'c>) : 'a -> 'b -> Async<'c> =
+    let tc = new TimedCounter(log, float periodMs)
+    throughputAsync2To tc count f
+
+
+
+
+  let latencyAsyncTo (hist:IntHistogram) (f:'a -> Async<'b>) : 'a -> Async<'b> =
+    fun a -> async {
+      let t1 = Stopwatch.GetTimestamp ()
+      let! b = f a
+      let t2 = Stopwatch.GetTimestamp ()
+      hist.Record (int (TimeSpan(t2 - t1).TotalMilliseconds))
+      return b }
+
+  let latencyAsync (log:Logger) (periodMs:int) (f:'a -> Async<'b>) : 'a -> Async<'b> =
+    let hist = new IntHistogram(log, float periodMs)
+    latencyAsyncTo hist f
+    

--- a/tests/kafunk.Tests/ProducerConsumer.fsx
+++ b/tests/kafunk.Tests/ProducerConsumer.fsx
@@ -51,7 +51,7 @@ let producer () = async {
       let messages = 
         Seq.init batchSize (fun j -> message (i * batchSize + j))
         |> Seq.toArray
-      let! res = Producer.produce producer messages
+      let! res = Producer.produce producer messages.[0]
       return () })
     |> Async.ParallelThrottledIgnore producerThreads
 

--- a/tests/kafunk.Tests/kafunk.Tests.fsproj
+++ b/tests/kafunk.Tests/kafunk.Tests.fsproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="Shared.fs" />
+    <Compile Include="Metrics.fs" />
     <Compile Include="PreludeTests.fs" />
     <Compile Include="CodecTests.fs" />
     <Compile Include="TcpTests.fs" />


### PR DESCRIPTION
This PR implements producer buffering. A producer message is assigned a partition using the partition function, and is then routed to a buffer corresponding to the broker which is the leader for that partition. Broker buffers are batched by size and linger as specified by configuration, and then sent as ProduceRequests. This creates 3 new config points for the producer:

- `bufferSize`: the size of the producer message buffer. When the buffer reaches capacity, back pressure is exerted on producers.
- `batchSize`: the maximum size of a batch of produce messages sent as part of a ProduceRequest to a broker.
- `batchLinger` the maximum time to wait for a batch to fill. To be configured in conjunction with `batchSize` to trade throughput vs. latency.