### PR TITLE
Bug/offset fetch api versions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 0.1.12
+* Added support for all versions of the OffsetFetch API in the Kafka protocol.
+
 ### 0.1.11 - 17.11.2017
 * BREAKING: Offset commit queue is moved to module `PeriodicCommitQueue`. See: https://jet.github.io/kafunk/consuming.html#Periodic-Offset-Commit.
 * Producer performance improvements.

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -393,17 +393,19 @@ type private RetryAction =
           |> Option.map (fun action -> r.errorCode,action)
 
       | ResponseMessage.OffsetFetchResponse r -> 
-        // TODO: duplicate error logic below for the entire response if the api version is v2
-        r.topics
-        |> Seq.tryPick (fun (_t,ps) ->
-          ps
-          |> Seq.tryPick (fun (_p,_o,_md,ec) -> 
-            match ec with
-            | ErrorCode.UnknownMemberIdCode | ErrorCode.IllegalGenerationCode | ErrorCode.RebalanceInProgressCode ->
-              Some (ec,RetryAction.PassThru)
-            | _ ->
-              RetryAction.errorRetryAction ec
-              |> Option.map (fun action -> ec,action)))
+        match r.errorCode with
+        | Some eCode -> Some (eCode, RetryAction.PassThru)
+        | None ->
+            r.topics
+            |> Seq.tryPick (fun (_t,ps) ->
+              ps
+              |> Seq.tryPick (fun (_p,_o,_md,ec) -> 
+                match ec with
+                | ErrorCode.UnknownMemberIdCode | ErrorCode.IllegalGenerationCode | ErrorCode.RebalanceInProgressCode ->
+                  Some (ec,RetryAction.PassThru)
+                | _ ->
+                  RetryAction.errorRetryAction ec
+                  |> Option.map (fun action -> ec,action)))
 
       | ResponseMessage.OffsetCommitResponse r ->
         r.topics

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -393,6 +393,7 @@ type private RetryAction =
           |> Option.map (fun action -> r.errorCode,action)
 
       | ResponseMessage.OffsetFetchResponse r -> 
+        // TODO: duplicate error logic below for the entire response if the api version is v2
         r.topics
         |> Seq.tryPick (fun (_t,ps) ->
           ps

--- a/src/kafunk/Protocol.fs
+++ b/src/kafunk/Protocol.fs
@@ -947,9 +947,10 @@ module Protocol =
   [<NoEquality;NoComparison>]
   type OffsetFetchResponse =
     struct
+      val throttleTime : ThrottleTime
       val topics : (TopicName * (Partition * Offset * Meta * ErrorCode)[])[]
       val errorCode : ErrorCode option
-      new (topics, errorCode) = { topics = topics; errorCode = errorCode }
+      new (topics, errorCode, throttleTime) = { topics = topics; errorCode = errorCode; throttleTime = throttleTime }
     end
   with
 
@@ -973,17 +974,16 @@ module Protocol =
         | 0s 
         | 1s -> 
             let topics = readTopics buf
-            OffsetFetchResponse(topics, None)    
+            OffsetFetchResponse(topics, None, 0)    
         | 2s -> 
             let topics = readTopics buf
             let errorCode = buf.ReadInt16()
-            OffsetFetchResponse(topics, Some errorCode) 
+            OffsetFetchResponse(topics, Some errorCode, 0) 
         | 3s -> 
-            // TODO: add somewhere?
             let throttleTimeMs = buf.ReadInt32()
             let topics = readTopics buf
             let errorCode = buf.ReadInt16()
-            OffsetFetchResponse(topics, Some errorCode)
+            OffsetFetchResponse(topics, Some errorCode, throttleTimeMs)
         | _ -> 
             failwithf "Unsupported API Version: %i" version
 


### PR DESCRIPTION
Added support for Kafka API versions for OffsetFetchRequest and OffsetFetchResponse as documented at http://kafka.apache.org/protocol.html#The_Messages_OffsetFetch.