### PR TITLE
Consumers no longer crash if no partitions assigned

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,4 @@
 ### 0.1.13 
-* Added support for all versions of the OffsetFetch API in the Kafka protocol.
 * Consumers will continue to run if not assigned partitions.
 
 ### 0.1.12 - 13.12.2017

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 0.1.13 
+* Added support for all versions of the OffsetFetch API in the Kafka protocol.
+* Consumers will continue to run if not assigned partitions.
+
 ### 0.1.12 - 13.12.2017
 * Buffering producer
 

--- a/src/kafunk/Consumer.fs
+++ b/src/kafunk/Consumer.fs
@@ -800,9 +800,8 @@ module Consumer =
       c.conn.Config.connId cfg.groupId topic (Printers.partitions assignment)
       
     if assignment.Length = 0 then
-      Log.error "no_partitions_assigned|conn_id=%s group_id=%s member_id=%s topic=%s" 
+      Log.warn "no_partitions_assigned|conn_id=%s group_id=%s member_id=%s topic=%s" 
         c.conn.Config.connId cfg.groupId state.state.memberId topic
-      return failwithf "no partitions assigned!"
 
     let! ct = Async.CancellationToken
     let fetchProcessCancellation = CancellationTokenSource.CreateLinkedTokenSource (ct, state.state.closed)


### PR DESCRIPTION
Fixes #186. This allows consumers to join the group and await partition assignment, for faster partition reassignment if another consumer fails.