### PR TITLE
Protocol v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Please also join the [F# Open Source Group](http://fsharp.github.com)
 
 ## Version Support
 
-| Version   | Status   |
-| ----------|----------|
-| 0.9.0     | Complete |
-| 0.10.0    | Complete |
-| 0.10.1    | Complete |
+| Version    | Status   |
+| -----------|----------|
+| 0.9.0      | Complete |
+| 0.10.0     | Complete |
+| 0.10.1     | Complete |
+| 0.11+auto  | Protocol |
 
 ## Feature Support
 
@@ -28,6 +29,7 @@ Please also join the [F# Open Source Group](http://fsharp.github.com)
 | TLS       | https://github.com/jet/kafunk/issues/66  |
 | SASL      | https://github.com/jet/kafunk/issues/139 |
 | ACL       | https://github.com/jet/kafunk/issues/140 |
+| TXNS      | https://github.com/jet/kafunk/issues/214 |
 
 
 ## Hello World

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
 ### 0.1.15-alpha02 - 14.3.2018
 * IMPROVE: support for v0.11 of broker protocol, including v5 of Fetch and v3 of Produce APIs
+* IMPROVE: improved TCP connection logging and log levels to reduce "false positives"
 * BREAKING: FetchResponse item now explicit structure rather than tuple. Breaking only if using low-level Fetch API.
-* FEATURE: ProducerQueueType to allow configuration of producer message queue networks.
+* FEATURE: `ProducerQueueType` to allow configuration of producer message queue networks.
+* BUG: consumer doesn't recover from `leaderless_partition_detected` #204
 
 ### 0.1.15-alpha01 - 5.3.2018
 * BUG: consumer would enter an infinite loop between `offsets_out_of_range` and `resuming_fetch_from_reset_offsets`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 0.1.15-alpha02 - 14.3.2018
+* IMPROVE: support for v0.11 of broker protocol, including v5 of Fetch and v3 of Produce APIs
+* BREAKING: FetchResponse item now explicit structure rather than tuple. Breaking only if using low-level Fetch API.
+* FEATURE: ProducerQueueType to allow configuration of producer message queue networks.
+
 ### 0.1.15-alpha01 - 5.3.2018
 * BUG: consumer would enter an infinite loop between `offsets_out_of_range` and `resuming_fetch_from_reset_offsets`
 * BUG: stalled consumers after TCP connection timeout

--- a/paket.lock
+++ b/paket.lock
@@ -10,7 +10,7 @@ GROUP Build
 RESTRICTION: == net45
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    FAKE (4.64.6)
+    FAKE (4.64.11)
     FSharp.Compiler.Service (2.0.0.6)
     FSharp.Formatting (2.14.4)
       FSharp.Compiler.Service (2.0.0.6)
@@ -20,7 +20,7 @@ NUGET
     Octokit (0.29)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (dd92a63bf27cae3f34c0ca142102e37fd4af3d70)
+    modules/Octokit/Octokit.fsx (96f1594fd50ced6c1aa45d7cf74fb6c067d08ac1)
       Octokit (>= 0.20)
 GROUP Legacy
 RESTRICTION: == net45
@@ -77,12 +77,12 @@ NUGET
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (== net45) (>= netstandard1.3)) (&& (== net45) (>= netstandard1.6)) (== netcoreapp2.0)
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (== net45) (>= netstandard1.3)) (&& (== net45) (>= netstandard1.6)) (== netcoreapp2.0)
       System.Linq (>= 4.1) - restriction: || (&& (== net45) (>= netstandard1.3)) (&& (== net45) (>= netstandard1.6)) (== netcoreapp2.0)
-    Microsoft.NET.Test.Sdk (15.6)
+    Microsoft.NET.Test.Sdk (15.6.1)
       Microsoft.CodeCoverage (>= 1.0.3)
-      Microsoft.TestPlatform.TestHost (>= 15.6) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-    Microsoft.NETCore.Platforms (2.0.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (&& (== net45) (>= netcoreapp2.0)) (== netcoreapp2.0)
-    Microsoft.NETCore.Targets (2.0) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-    Microsoft.TestPlatform.ObjectModel (15.6) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+      Microsoft.TestPlatform.TestHost (>= 15.6.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    Microsoft.NETCore.Platforms (2.0.1) - restriction: || (&& (== net45) (>= netcoreapp2.0)) (== netcoreapp2.0)
+    Microsoft.NETCore.Targets (2.0) - restriction: == netcoreapp2.0
+    Microsoft.TestPlatform.ObjectModel (15.6.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       NETStandard.Library (>= 1.6) - restriction: || (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
       System.ComponentModel.EventBasedAsync (>= 4.0.11) - restriction: || (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
       System.ComponentModel.TypeConverter (>= 4.1) - restriction: || (&& (== net45) (>= netstandard1.4)) (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
@@ -97,9 +97,9 @@ NUGET
       System.Runtime.Serialization.Primitives (>= 4.1.1) - restriction: || (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
       System.Threading.Thread (>= 4.0) - restriction: || (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
       System.Xml.XPath.XmlDocument (>= 4.0.1) - restriction: || (&& (== net45) (>= netstandard1.5)) (== netcoreapp2.0)
-    Microsoft.TestPlatform.TestHost (15.6) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    Microsoft.TestPlatform.TestHost (15.6.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       Microsoft.Extensions.DependencyModel (>= 1.0.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-      Microsoft.TestPlatform.ObjectModel (>= 15.6) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (&& (== net45) (>= uap10.0)) (== netcoreapp2.0)
+      Microsoft.TestPlatform.ObjectModel (>= 15.6.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (&& (== net45) (>= uap10.0)) (== netcoreapp2.0)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (&& (== net45) (>= uap10.0)) (== netcoreapp2.0)
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
@@ -109,7 +109,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: || (&& (== net45) (>= netcoreapp2.0)) (== netcoreapp2.0)
       System.Security.AccessControl (>= 4.4) - restriction: || (&& (== net45) (>= monoandroid)) (&& (== net45) (>= monotouch)) (&& (== net45) (>= net461)) (&& (== net45) (>= netcoreapp2.0)) (&& (== net45) (>= netstandard2.0)) (&& (== net45) (>= xamarinios)) (&& (== net45) (>= xamarinmac)) (&& (== net45) (>= xamarintvos)) (&& (== net45) (>= xamarinwatchos)) (== netcoreapp2.0)
       System.Security.Principal.Windows (>= 4.4) - restriction: || (&& (== net45) (>= monoandroid)) (&& (== net45) (>= monotouch)) (&& (== net45) (>= net461)) (&& (== net45) (>= netcoreapp2.0)) (&& (== net45) (>= netstandard2.0)) (&& (== net45) (>= xamarinios)) (&& (== net45) (>= xamarinmac)) (&& (== net45) (>= xamarintvos)) (&& (== net45) (>= xamarinwatchos)) (== netcoreapp2.0)
-    NETStandard.Library (2.0.1) - restriction: || (&& (== net45) (>= monoandroid)) (&& (== net45) (< net20) (>= netstandard1.3)) (&& (== net45) (< net20) (>= netstandard1.6)) (&& (== net45) (>= uap10.0)) (&& (== net45) (>= xamarinios)) (== netcoreapp2.0)
+    NETStandard.Library (2.0.1) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1)
     Newtonsoft.Json (11.0.1) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
     NUnit (3.9)
@@ -129,12 +129,13 @@ NUGET
       NUnit.Extension.NUnitV2ResultWriter (>= 3.5)
       NUnit.Extension.TeamCityEventListener (>= 1.0.3)
       NUnit.Extension.VSProjectLoader (>= 3.7)
-    NUnit3TestAdapter (3.9)
+    NUnit3TestAdapter (3.10)
       Microsoft.DotNet.InternalAbstractions (>= 1.0) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.ComponentModel.EventBasedAsync (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.ComponentModel.TypeConverter (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Diagnostics.Process (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Reflection (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Threading.Thread (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Xml.XPath.XmlDocument (>= 4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
@@ -143,7 +144,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1)
     System.AppContext (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (&& (== net45) (>= netstandard1.3)) (&& (== net45) (>= netstandard1.6)) (== netcoreapp2.0)
-    System.Collections (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Collections (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
@@ -206,7 +207,7 @@ NUGET
       System.IO (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Text.Encoding (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
-    System.Diagnostics.Debug (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Diagnostics.Debug (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
@@ -283,7 +284,7 @@ NUGET
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Runtime.Extensions (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
-    System.IO (4.3) - restriction: || (&& (== net45) (< net20) (>= netstandard1.6)) (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.IO (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
@@ -356,7 +357,7 @@ NUGET
       System.Xml.XDocument (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (&& (== net45) (>= net46)) (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Xml.XmlSerializer (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
-    System.Reflection (4.3) - restriction: || (&& (== net45) (< net20) (>= netstandard1.6)) (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Reflection (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.IO (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
@@ -383,25 +384,25 @@ NUGET
       System.Reflection (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
     System.Reflection.Metadata (1.5) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-    System.Reflection.Primitives (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Reflection.Primitives (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
     System.Reflection.TypeExtensions (4.4) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-    System.Resources.ResourceManager (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Resources.ResourceManager (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Globalization (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Reflection (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
-    System.Runtime (4.3) - restriction: || (&& (== net45) (< net20) (>= netstandard1.6)) (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Runtime (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
     System.Runtime.Extensions (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
-    System.Runtime.Handles (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Runtime.Handles (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
@@ -436,7 +437,7 @@ NUGET
       System.Security.Principal.Windows (>= 4.4) - restriction: || (&& (== net45) (>= monoandroid)) (&& (== net45) (>= monotouch)) (&& (== net45) (>= net46)) (&& (== net45) (>= net461)) (&& (== net45) (>= netcoreapp2.0)) (&& (== net45) (>= netstandard1.3)) (&& (== net45) (>= netstandard2.0)) (&& (== net45) (>= xamarinios)) (&& (== net45) (>= xamarinmac)) (&& (== net45) (>= xamarintvos)) (&& (== net45) (>= xamarinwatchos)) (== netcoreapp2.0)
     System.Security.Principal.Windows (4.4.1) - restriction: || (&& (== net45) (>= monoandroid) (>= netcoreapp1.0)) (&& (== net45) (>= monotouch) (>= netcoreapp1.0)) (&& (== net45) (>= net461) (>= netcoreapp1.0)) (&& (== net45) (>= netcoreapp1.0) (>= netstandard2.0)) (&& (== net45) (>= netcoreapp1.0) (>= xamarinios)) (&& (== net45) (>= netcoreapp1.0) (>= xamarinmac)) (&& (== net45) (>= netcoreapp1.0) (>= xamarintvos)) (&& (== net45) (>= netcoreapp1.0) (>= xamarinwatchos)) (&& (== net45) (>= netcoreapp2.0)) (== netcoreapp2.0)
       Microsoft.NETCore.Platforms (>= 2.0) - restriction: || (&& (== net45) (>= netcoreapp2.0)) (== netcoreapp2.0)
-    System.Text.Encoding (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Text.Encoding (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
@@ -450,12 +451,12 @@ NUGET
     System.Threading (4.3) - restriction: == netcoreapp2.0
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Threading.Tasks (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
-    System.Threading.Tasks (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Threading.Tasks (4.3) - restriction: == netcoreapp2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= dnxcore50)) (== netcoreapp2.0)
     System.Threading.Tasks.Extensions (4.4) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
-    System.Threading.Thread (4.3) - restriction: || (&& (== net45) (< net20) (>= netstandard1.6)) (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
+    System.Threading.Thread (4.3) - restriction: || (&& (== net45) (< net20) (>= netstandard1.6)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)
     System.Threading.ThreadPool (4.3) - restriction: || (&& (== net45) (>= netcoreapp1.0)) (== netcoreapp2.0)
       System.Runtime (>= 4.3) - restriction: || (&& (== net45) (>= netstandard1.3)) (== netcoreapp2.0)

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -219,7 +219,7 @@ module internal Chan =
       socketAgent
       |> Resource.injectWithRecovery
           RetryPolicy.none
-          (fun s buf -> Socket.sendAll s buf |> Async.Catch |> Async.map (Result.mapError (ResourceErrorAction.CloseRetry)))
+          (fun s buf -> Socket.sendAll s buf |> Async.Catch |> Async.map (Result.mapError (Some >> ResourceErrorAction.CloseRetry)))
 
     let receive =
       let receive s buf = async {
@@ -298,7 +298,7 @@ module internal Chan =
       let send session req = 
         Session.send session req
         |> Async.map (function 
-          | None -> Failure (CloseRetry (exn "timeout"))
+          | None -> Failure (CloseRetry None)
           | Some res -> Success (Success res))
       sessionAgent
       |> Resource.injectWithRecovery config.requestRetryPolicy send

--- a/src/kafunk/Chan.fs
+++ b/src/kafunk/Chan.fs
@@ -264,7 +264,20 @@ module internal Chan =
       //  let path = sprintf "%s_%s.bin" (apiKey.ToString().ToLower()) (Guid.NewGuid().ToString("N"))
       //  System.IO.File.WriteAllBytes(path, Binary.toArray buf)
       //| _ -> ()
-      ResponseMessage.Read (apiKey,apiVer,BinaryZipper(buf))
+      let res = ResponseMessage.Read (apiKey,apiVer,BinaryZipper(buf))
+      //match res with
+      //| ResponseMessage.FetchResponse res ->
+      //  let ps =           
+      //    res.topics
+      //    |> Seq.map (fun (_t,ps) ->            
+      //      ps
+      //      |> Seq.map (fun (p,_,_,_,_,_,_,_) -> sprintf "p=%i" p)
+      //      |> String.concat "_")
+      //    |> String.concat "_"                      
+      //  let path = sprintf "%s_%s_%s.bin" (apiKey.ToString().ToLower()) ps (Guid.NewGuid().ToString("N"))
+      //  System.IO.File.WriteAllBytes(path, Binary.toArray buf)
+      //| _ -> ()
+      res
 
     let! sessionAgent = 
       Resource.create 

--- a/src/kafunk/Compression.fs
+++ b/src/kafunk/Compression.fs
@@ -8,30 +8,31 @@ open Kafunk
 
 let private createMessage (value:Value) (compression:byte) =
   let attrs = compression |> int8
-  Message.create value Binary.empty (Some attrs)
+  //Message.create value Binary.empty (Some attrs)
+  Message(0, 0y, attrs, 0L, Binary.empty, value)
 
 [<RequireQualifiedAccess>]
 module internal Stream = 
 
   // The only thing that can be compressed is a MessageSet, not a single Message; this results in a message containing the compressed set
-  let compress (codec:CompressionCodec) (makeStream:MemoryStream -> Stream) (messageVer:ApiVersion) (ms:MessageSet) =
+  let compress (codec:CompressionCodec) (makeStream:MemoryStream -> Stream) (ms:MessageSet) =
     use outputStream = new MemoryStream()
     do
-      let buf = MessageSet.Size (messageVer,ms) |> Binary.zeros
-      MessageSet.Write (messageVer,ms,BinaryZipper(buf))
+      let buf = MessageSet.Size ms |> Binary.zeros
+      MessageSet.Write (ms,BinaryZipper(buf))
       use compStream = makeStream outputStream
       compStream.Write(buf.Array, buf.Offset, buf.Count)
     let value = Binary.Segment(outputStream.GetBuffer(), 0, int outputStream.Length)
     createMessage value codec
 
-  let decompress (makeStream:MemoryStream -> Stream) (messageVer:ApiVersion) (m:Message) =
+  let decompress (makeStream:MemoryStream -> Stream) (magicByte:int8) (m:Message) =
     use outputStream = new MemoryStream()
     do
       use inputStream = new MemoryStream(m.value.Array, m.value.Offset, m.value.Count)
       use compStream = makeStream inputStream
       compStream.CopyTo(outputStream)
     let buf = Binary.Segment(outputStream.GetBuffer(), 0, int outputStream.Length)
-    MessageSet.Read (messageVer, 0, 0s, buf.Count, true, BinaryZipper(buf))
+    MessageSet.Read (magicByte, 0, 0s, buf.Count, true, BinaryZipper(buf))
 
 [<Compile(Module)>]
 module GZip =
@@ -39,11 +40,10 @@ module GZip =
   open System.IO
   open System.IO.Compression
 
-  let compress ver ms =
+  let compress ms =
     Stream.compress 
       CompressionCodec.GZIP 
       (fun memStream -> upcast new GZipStream(memStream, CompressionMode.Compress, true))
-      ver
       ms
 
   let decompress ver m =
@@ -145,30 +145,30 @@ module Snappy =
       let actualLength = SnappyCodec.Uncompress(content.Array, content.Offset, content.Count, buf, 0)
       Binary.truncateIfSmaller actualLength uncompressedLength buf
 
-  let compress (messageVer:ApiVersion) (ms:MessageSet) =
-    let buf = MessageSet.Size (messageVer,ms) |> Binary.zeros
-    MessageSet.Write (messageVer,ms,BinaryZipper(buf))
+  let compress (ms:MessageSet) =
+    let buf = MessageSet.Size ms |> Binary.zeros
+    MessageSet.Write (ms,BinaryZipper(buf))
     let output = CompressedMessage.compress buf 
     createMessage output CompressionCodec.Snappy
     
-  let decompress (messageVer:ApiVersion) (m:Message) =
+  let decompress (magicByte:int8) (m:Message) =
     let buf = CompressedMessage.decompress m.value 
-    MessageSet.Read (messageVer, 0, 0s, buf.Count, true, BinaryZipper(buf))
+    MessageSet.Read (magicByte, 0, 0s, buf.Count, true, BinaryZipper(buf))
 
 #endif
   
-let compress (messageVer:int16) (compression:byte) (ms:MessageSet) =
+let compress (compression:byte) (ms:MessageSet) =
   match compression with
   | CompressionCodec.None -> ms
-  | CompressionCodec.GZIP -> MessageSet.ofMessage messageVer (GZip.compress messageVer ms)
+  | CompressionCodec.GZIP -> MessageSet.ofMessage (GZip.compress ms)
 
 #if !NETSTANDARD2_0
-  | CompressionCodec.Snappy -> MessageSet.ofMessage messageVer (Snappy.compress messageVer ms)
+  | CompressionCodec.Snappy -> MessageSet.ofMessage (Snappy.compress ms)
 #endif
 
   | _ -> failwithf "Incorrect compression codec %A" compression
   
-let decompress (messageVer:int16) (ms:MessageSet) =
+let decompress (magicByte:int8) (ms:MessageSet) =
   if ms.messages.Length = 0 then ms
   else
     ms.messages
@@ -176,12 +176,12 @@ let decompress (messageVer:int16) (ms:MessageSet) =
       match (msi.message.attributes &&& (sbyte CompressionCodec.Mask)) |> byte with
       | CompressionCodec.None -> [|msi|]
       | CompressionCodec.GZIP ->
-        let decompressed = GZip.decompress messageVer msi.message
+        let decompressed = GZip.decompress magicByte msi.message
         decompressed.messages
 
 #if !NETSTANDARD2_0    
       | CompressionCodec.Snappy ->
-        let decompressed = Snappy.decompress messageVer msi.message
+        let decompressed = Snappy.decompress magicByte msi.message
         decompressed.messages
 #endif
 

--- a/src/kafunk/Helpers.fs
+++ b/src/kafunk/Helpers.fs
@@ -5,25 +5,26 @@ open Kafunk
 open System
 open System.Text
 
-module Message =
+//module Message =
 
-  let create value key attrs =
-    // NB: the CRC is computed by the Protocol module during encoding
-    //Message(0, 0y, (defaultArg attrs 0y), DateTime.UtcNowUnixMilliseconds, key, value)
-    Message(0, 0y, (defaultArg attrs 0y), 0L, key, value)
+//  let create value key attrs =
+//    // NB: the CRC is computed by the Protocol module during encoding
+//    //Message(0, 0y, (defaultArg attrs 0y), DateTime.UtcNowUnixMilliseconds, key, value)
+//    Message(0, 0y, (defaultArg attrs 0y), 0L, key, value)
 
 module MessageSet =
 
-  let ofMessage (messageVer:ApiVersion) (m:Message) =
-    MessageSet([| MessageSetItem(0L, Message.Size (messageVer,m), m) |])
+  let t = DateTime.UtcNowUnixMilliseconds
 
-  let ofMessages (messageVer:ApiVersion) ms =
-    MessageSet(ms |> Seq.map (fun m -> MessageSetItem (0L, Message.Size (messageVer,m), m)) |> Seq.toArray)
+  let ofMessage (m:Message) =
+    MessageSet([| MessageSetItem(0L, Message.Size m, m) |])
+
+  let ofMessages ms =
+    MessageSet(ms |> Seq.map (fun m -> MessageSetItem (0L, Message.Size m, m)) |> Seq.toArray)
 
   /// Returns the frist offset in the message set.
   let firstOffset (ms:MessageSet) =
     if ms.messages.Length > 0 then
-      //let (o,_,_) = ms.messages.[0] in o
        ms.messages.[0].offset
     else
       0L
@@ -31,8 +32,7 @@ module MessageSet =
   /// Returns the last offset in the message set.
   let lastOffset (ms:MessageSet) =
     if ms.messages.Length > 0 then
-      //let (o,_,_) = ms.messages.[ms.messages.Length - 1] in o
-      ms.messages.[ms.messages.Length - 1].offset
+      max ms.lastOffset (ms.messages.[ms.messages.Length - 1].offset)
     else
       0L
 
@@ -185,7 +185,7 @@ module internal Printers =
         |> Seq.map (fun x ->
           let ps =
             x.partitions
-            |> Seq.map (fun y -> sprintf "p=%i o=%i error_code=%i" y.partition y.offset y.errorCode)
+            |> Seq.map (fun y -> sprintf "p=%i o=%i ec=%i" y.partition y.offset y.errorCode)
             |> String.concat " ; "
           sprintf "topic=%s partitions=[%s]" x.topic ps)
         |> String.concat " ; "
@@ -198,11 +198,11 @@ module internal Printers =
         |> Seq.map (fun (tn,ps) ->
           let ps = 
             ps
-            |> Seq.map (fun (p,o,_,_mb) -> sprintf "(p=%i o=%i)" p o)
+            |> Seq.map (fun (p,o,_,mb) -> sprintf "(p=%i o=%i mb=%i)" p o mb)
             |> String.concat " ; "
           sprintf "topic=%s partitions=[%s]" tn ps)
         |> String.concat " ; "
-      sprintf "FetchRequest|%s" ts
+      sprintf "FetchRequest|mb=%i %s" x.maxBytes ts
 
   type FetchResponse with
     static member Print (x:FetchResponse) =
@@ -217,7 +217,7 @@ module internal Printers =
                 messageSet.messages 
                 |> Seq.tryItem 0 
                 |> Option.map (fun x -> sprintf " o=%i lag=%i" x.offset (highWatermark - x.offset)) |> Option.getOr ""
-              sprintf "(p=%i error_code=%i lso=%i hwo=%i mss=%i%s)" partition errorCode logStartOffset highWatermark messageSetSize offsetInfo)
+              sprintf "(p=%i ec=%i lso=%i hwo=%i mss=%i%s)" partition errorCode logStartOffset highWatermark messageSetSize offsetInfo)
             |> String.concat ";"
           sprintf "topic=%s partitions=[%s]" tn ps)
         |> String.concat " ; "

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -195,8 +195,8 @@ module internal Routing =
         reqs
         |> Seq.groupBy (fun (t, _, _, _) -> t)
         |> Seq.map (fun (t, ps) -> t, ps |> Seq.map (fun (_, p, o, mb) -> (p, o, 0L, mb)) |> Seq.toArray)
-        |> Seq.toArray
-      let req = new FetchRequest(req.replicaId, req.maxWaitTime, req.minBytes, topics, 0, 0y)
+        |> Seq.toArray      
+      let req = new FetchRequest(req.replicaId, req.maxWaitTime, req.minBytes, topics, req.maxBytes, 0y)
       ch, RequestMessage.Fetch req)
     |> Seq.toArray
 
@@ -774,11 +774,13 @@ type KafkaConn internal (cfg:KafkaConfig) =
     let! ch = getBrokerChan critical state b
     match ch with
     | Success ch ->
-      //Log.trace "sending_to_broker|node_id=%i ep=%O req=%s" b.nodeId (Broker.endpoint b) (RequestMessage.Print req)
+      //Log.info "sending_to_broker|node_id=%i ep=%O req=%s" b.nodeId (Broker.endpoint b) (RequestMessage.Print req)
       try
         let! chanRes = Chan.send ch req
         match chanRes with
         | Success res ->
+          //Log.info "received_response|node_id=%i ep=%O req=%s res=%s" 
+          //  b.nodeId (Broker.endpoint b) (RequestMessage.Print req) (ResponseMessage.Print res)
           return Success res
         | Failure errs ->
           let! _state =

--- a/src/kafunk/Kafka.fs
+++ b/src/kafunk/Kafka.fs
@@ -71,9 +71,14 @@ type internal ClusterState = {
         match Map.tryFind nodeId brokersById with
         | Some b -> Some ((t,p),b)
         | None -> None)
+    let removeTopicPartitions =
+      topicNodes |> Seq.choose (fun (t,p,n) -> if n < 0 then Some (t,n) else None)        
     { s with
           brokersByNodeId = brokersById
-          brokersByTopicPartition = s.brokersByTopicPartition |> Map.addMany brokersByPartitions
+          brokersByTopicPartition = 
+            s.brokersByTopicPartition 
+            |> Map.addMany brokersByPartitions
+            |> Map.removeAll removeTopicPartitions
           version = s.version + 1 }
 
   static member updateGroupCoordinator (broker:Broker, gid:GroupId) (s:ClusterState) =
@@ -339,6 +344,8 @@ type private RetryAction =
       
       | ErrorCode.UnknownTopicOrPartition ->
         Some (RetryAction.Escalate)
+        //Some (RetryAction.RefreshMetadataAndRetry)
+
       | ErrorCode.InvalidMessage ->
         Some (RetryAction.Escalate)
       | _ ->
@@ -348,9 +355,13 @@ type private RetryAction =
       match res with
       | ResponseMessage.MetadataResponse r ->
         r.topicMetadata
-        |> Seq.tryPick (fun x -> 
-          RetryAction.errorRetryAction x.topicErrorCode
-          |> Option.map (fun action -> x.topicErrorCode,action))
+        |> Seq.tryPick (fun x ->
+          match x.topicErrorCode with
+          | ErrorCode.UnknownTopicOrPartition -> 
+            Some (x.topicErrorCode,RetryAction.RefreshMetadataAndRetry [|x.topicName|])
+          | _ ->
+            RetryAction.errorRetryAction x.topicErrorCode
+            |> Option.map (fun action -> x.topicErrorCode,action))
 
       | ResponseMessage.OffsetResponse r ->
         r.topics
@@ -367,10 +378,12 @@ type private RetryAction =
         r.topics 
         |> Seq.tryPick (fun (topicName,partitionMetadata) -> 
           partitionMetadata 
-          |> Seq.tryPick (fun (_,ec,_,_,_,_,_,_) -> 
+          |> Seq.tryPick (fun p -> 
+            let ec = p.errorCode
             match ec with
             | ErrorCode.NoError -> None
-            | ErrorCode.NotLeaderForPartition -> Some (ec, RetryAction.RefreshMetadataAndRetry [|topicName|])
+            | ErrorCode.NotLeaderForPartition | ErrorCode.UnknownTopicOrPartition -> 
+              Some (ec, RetryAction.RefreshMetadataAndRetry [|topicName|])
             | ec ->
               RetryAction.errorRetryAction ec
               |> Option.map (fun action -> ec, action)))
@@ -510,8 +523,8 @@ type KafkaConfig = {
   /// The default Kafka server version = 0.10.1.
   static member DefaultVersion = Version.Parse "0.10.1"
 
-  /// The default setting for supporting auto API versions = false.
-  static member DefaultAutoApiVersions = false
+  /// The default setting for supporting auto API versions = true.
+  static member DefaultAutoApiVersions = true
 
   /// The default broker channel configuration.
   static member DefaultChanConfig = ChanConfig.create ()
@@ -555,6 +568,8 @@ type KafkaConn internal (cfg:KafkaConfig) =
   
   do Log.info "created_conn|api_version=%O auto_api_versions=%b client_version=%O client_id=%s conn_id=%s" 
         cfg.version cfg.autoApiVersions (Assembly.executingAssemblyVersion ()) cfg.clientId cfg.connId
+
+  do if String.IsNullOrEmpty cfg.clientId then Log.warn "client_id_unspecified"
 
   let apiVersion = ref (Versions.byVersion cfg.version)
   let stateCell : MVar<ClusterState> = MVar.createFull (ClusterState.Zero)
@@ -672,10 +687,10 @@ type KafkaConn internal (cfg:KafkaConfig) =
     else getAndApplyBootstrap
 
   /// Fetches metadata and returns an updated connection state.
-  and metadata (state:ClusterState) (topics:TopicName[]) = async {
+  and metadata (state:ClusterState) (rs:RetryState) (topics:TopicName[]) = async {
     
     let send =
-      routeToBrokerWithRecovery true RetryState.init state
+      routeToBrokerWithRecovery true rs state
       |> AsyncFunc.dimap RequestMessage.Metadata ResponseMessage.toMetadata
     
     let! metadata = send (MetadataRequest(topics))
@@ -685,7 +700,7 @@ type KafkaConn internal (cfg:KafkaConfig) =
     for tmd in metadata.topicMetadata do
       for pmd in tmd.partitionMetadata do
         if pmd.leader = -1 then
-          Log.error "leaderless_partition_detected|partition=%i error_code=%i" pmd.partitionId pmd.partitionErrorCode
+          Log.error "leaderless_partition_detected|topic=%s partition=%i error_code=%i" tmd.topicName pmd.partitionId pmd.partitionErrorCode
       
     let topicNodes =
       metadata.topicMetadata 
@@ -697,7 +712,7 @@ type KafkaConn internal (cfg:KafkaConfig) =
     return state |> ClusterState.updateMetadata (metadata.brokers, topicNodes) }
 
   /// Fetches and applies metadata to the current connection.
-  and getAndApplyMetadata (requireMatchingCaller:bool) (callerState:ClusterState) (topics:TopicName[]) =
+  and getAndApplyMetadata (requireMatchingCaller:bool) (callerState:ClusterState) (rs:RetryState) (topics:TopicName[]) =
     stateCell
     |> MVar.updateAsync (fun (currentState:ClusterState) -> async {
       if requireMatchingCaller 
@@ -706,7 +721,7 @@ type KafkaConn internal (cfg:KafkaConfig) =
         Log.trace "skipping_metadata_update|current_version=%i caller_version=%i" currentState.version callerState.version
         return currentState 
       else
-        return! metadata currentState topics })
+        return! metadata currentState rs topics })
 
   /// Refreshes metadata for existing topics.
   and refreshMetadata (critical:bool) (callerState:ClusterState) =
@@ -719,8 +734,8 @@ type KafkaConn internal (cfg:KafkaConfig) =
   and refreshMetadataFor (critical:bool) (callerState:ClusterState) topics =
     Log.info "refreshing_metadata|topics=%A version=%i bootstrap_broker=%A conn_id=%s" 
       topics callerState.version (callerState.bootstrapBroker |> Option.map (Broker.endpoint)) cfg.connId
-    if critical then metadata callerState topics
-    else getAndApplyMetadata true callerState topics
+    if critical then metadata callerState RetryState.init topics
+    else getAndApplyMetadata true callerState RetryState.init topics
 
   /// Fetches group coordinator metadata.
   and groupCoordinator (state:ClusterState) (groupId:GroupId) = async {
@@ -797,6 +812,9 @@ type KafkaConn internal (cfg:KafkaConfig) =
             else removeBrokerAndApply b state
           return Failure [ChanError.ChanFailure ex]
     | Failure errs ->
+      let! _state =
+        if critical then ClusterState.removeBroker b state
+        else removeBrokerAndApply b state
       return Failure errs }
 
   /// Sends a request to a specific broker and handles failures.
@@ -810,21 +828,21 @@ type KafkaConn internal (cfg:KafkaConfig) =
           | None -> 
             return res
           | Some (errorCode,action) ->
-            Log.warn "channel_response_errored|endpoint=%O error_code=%i retry_action=%A req=%s res=%s conn_id=%s" 
-              (Broker.endpoint b) errorCode action (RequestMessage.Print req) (ResponseMessage.Print res) cfg.connId
+            Log.warn "channel_response_errored|endpoint=%O error_code=%i retry_action=%A attempt=%i req=%s res=%s conn_id=%s" 
+              (Broker.endpoint b) errorCode action rs.attempt (RequestMessage.Print req) (ResponseMessage.Print res) cfg.connId
             match action with
             | RetryAction.PassThru ->
               return res
             | RetryAction.Escalate ->
               return raise (EscalationException (errorCode,req,res,(sprintf "endpoint=%O" (Broker.endpoint b))))
-            | RetryAction.RefreshMetadataAndRetry topics ->
+            | RetryAction.RefreshMetadataAndRetry topics ->              
               let! rs' = RetryPolicy.awaitNextState cfg.requestRetryPolicy rs
               match rs' with
-              | Some rs ->
+              | Some rs' ->
                 let! state' = 
-                  if critical then metadata state topics
-                  else getAndApplyMetadata true state topics
-                return! routeToBrokerWithRecovery critical rs state' req
+                  if critical then metadata state rs' topics
+                  else getAndApplyMetadata true state rs' topics
+                return! routeToBrokerWithRecovery critical rs' state' req
               | None ->
                 return failwithf "request_failure|attempt=%i request=%s response=%s" 
                   rs.attempt (RequestMessage.Print req) (ResponseMessage.Print res)
@@ -949,7 +967,7 @@ type KafkaConn internal (cfg:KafkaConfig) =
 
   member internal __.GetMetadataState (topics:TopicName[]) = async {
     let! state = MVar.get stateCell
-    return! getAndApplyMetadata false state topics }
+    return! getAndApplyMetadata false state RetryState.init topics }
 
   member internal __.GetMetadata (topics:TopicName[]) = async {
     let! state' = __.GetMetadataState topics

--- a/src/kafunk/Protocol.fs
+++ b/src/kafunk/Protocol.fs
@@ -3,6 +3,7 @@ namespace Kafunk
 /// The Kafka RPC protocol.
 [<AutoOpen>]
 module Protocol =
+  open System
 
   type ApiKey =
     | Produce = 0
@@ -26,14 +27,15 @@ module Protocol =
   module internal MessageVersions =
     
     /// Gets the version of Message for a ProduceRequest of the specified API version.
-    let internal produceReqMessage (apiVer:ApiVersion) =
-      if apiVer >= 2s then 1s
-      else 0s
+    let internal produceReqMessage (apiVer:ApiVersion) : int8 =
+      if apiVer >= 3s then 2y 
+      elif apiVer = 2s then 1y
+      else 0y
 
     /// Gets the version of Message for a FetchResponse of the specified API version.
-    let internal fetchResMessage (apiVer:ApiVersion) =
-      if apiVer >= 2s then 1s
-      else 0s
+    let internal fetchResMessage (apiVer:ApiVersion) : int8 =
+      if apiVer >= 2s then 1y
+      else 0y
 
   /// A correlation id of a Kafka request-response transaction.
   type CorrelationId = int32
@@ -357,6 +359,50 @@ module Protocol =
     new (msg,magicByte) = new MessageTooBigException (msg, null, magicByte, 0)
     new (msg,magicByte,messageSize) = new MessageTooBigException (msg, null, magicByte, messageSize)
 
+  module internal TimestampType =
+    
+    let [<Literal>] MASK = 0x80
+    let [<Literal>] CREATE_TIME = 0
+    let [<Literal>] LOG_APPEND_TIME = 1
+
+  module internal RecordBatch =
+
+    let OFFSET_OFFSET = 0
+    let OFFSET_LENGTH = 8
+    let SIZE_OFFSET = OFFSET_OFFSET + OFFSET_LENGTH
+    let SIZE_LENGTH = 4
+    let LOG_OVERHEAD = SIZE_OFFSET + SIZE_LENGTH
+
+    let BASE_OFFSET_OFFSET = 0;
+    let BASE_OFFSET_LENGTH = 8;
+    let LENGTH_OFFSET = BASE_OFFSET_OFFSET + BASE_OFFSET_LENGTH;
+    let LENGTH_LENGTH = 4
+    let PARTITION_LEADER_EPOCH_OFFSET = LENGTH_OFFSET + LENGTH_LENGTH;
+    let PARTITION_LEADER_EPOCH_LENGTH = 4;
+    let MAGIC_OFFSET = PARTITION_LEADER_EPOCH_OFFSET + PARTITION_LEADER_EPOCH_LENGTH;
+    let MAGIC_LENGTH = 1;
+    let CRC_OFFSET = MAGIC_OFFSET + MAGIC_LENGTH;
+    let CRC_LENGTH = 4;
+    let ATTRIBUTES_OFFSET = CRC_OFFSET + CRC_LENGTH;
+    let ATTRIBUTE_LENGTH = 2;
+    let LAST_OFFSET_DELTA_OFFSET = ATTRIBUTES_OFFSET + ATTRIBUTE_LENGTH;
+    let LAST_OFFSET_DELTA_LENGTH = 4;
+    let FIRST_TIMESTAMP_OFFSET = LAST_OFFSET_DELTA_OFFSET + LAST_OFFSET_DELTA_LENGTH;
+    let FIRST_TIMESTAMP_LENGTH = 8;
+    let MAX_TIMESTAMP_OFFSET = FIRST_TIMESTAMP_OFFSET + FIRST_TIMESTAMP_LENGTH;
+    let MAX_TIMESTAMP_LENGTH = 8;
+    let PRODUCER_ID_OFFSET = MAX_TIMESTAMP_OFFSET + MAX_TIMESTAMP_LENGTH;
+    let PRODUCER_ID_LENGTH = 8;
+    let PRODUCER_EPOCH_OFFSET = PRODUCER_ID_OFFSET + PRODUCER_ID_LENGTH;
+    let PRODUCER_EPOCH_LENGTH = 2;
+    let BASE_SEQUENCE_OFFSET = PRODUCER_EPOCH_OFFSET + PRODUCER_EPOCH_LENGTH;
+    let BASE_SEQUENCE_LENGTH = 4;
+    let RECORDS_COUNT_OFFSET = BASE_SEQUENCE_OFFSET + BASE_SEQUENCE_LENGTH;
+    let RECORDS_COUNT_LENGTH = 4;
+    let RECORDS_OFFSET = RECORDS_COUNT_OFFSET + RECORDS_COUNT_LENGTH;
+    let RECORD_BATCH_OVERHEAD = RECORDS_OFFSET;
+
+
   /// A Kafka message type used for producing and fetching.
   [<NoEquality;NoComparison>]
   type Message =
@@ -372,7 +418,7 @@ module Protocol =
     end
   with
 
-    static member Size (_messageVer:ApiVersion, m:Message) =
+    static member Size (m:Message) =
       Binary.sizeInt32 m.crc +
       Binary.sizeInt8 m.magicByte +
       Binary.sizeInt8 m.attributes +
@@ -380,7 +426,18 @@ module Protocol =
       Binary.sizeBytes m.key +
       Binary.sizeBytes m.value
 
-    static member Write (_messageVer:ApiVersion, m:Message, buf:BinaryZipper) =      
+    /// Returns the size of the record, excluding the size of the length field itself.
+    static member SizeRecord timestampDelta offsetDelta (m:Message) =
+      let size =
+        1 + // attributes
+        Binary.sizeVarint64 timestampDelta +
+        Binary.sizeVarint offsetDelta +          
+        Binary.sizeBytesVarint m.key +
+        Binary.sizeBytesVarint m.value +
+        Binary.sizeVarint 0 // headers length
+      size //+ Binary.sizeVarint size
+
+    static member Write (m:Message, buf:BinaryZipper) =      
       buf.ShiftOffset 4 // CRC
       let offsetAfterCrc = buf.Buffer.Offset
       buf.WriteInt8 m.magicByte
@@ -390,15 +447,16 @@ module Protocol =
       buf.WriteBytes m.key
       buf.WriteBytes m.value
       let crc = Crc.crc32 buf.Buffer.Array offsetAfterCrc (buf.Buffer.Offset - offsetAfterCrc)
-      let crcBuf = System.ArraySegment<_>(buf.Buffer.Array, offsetAfterCrc - 4, 4)
-      Binary.pokeInt32 (int crc) crcBuf |> ignore
+      //Binary.pokeInt32In (int crc) buf.Buffer.Array (offsetAfterCrc - 4)
+      Binary.pokeUInt32In (int64 crc) buf.Buffer.Array (offsetAfterCrc - 4)
 
-    static member Read (ver:ApiVersion, buf:BinaryZipper) =
+    static member Read (magicByte:int8, buf:BinaryZipper) =
       let crc = buf.ReadInt32 ()
-      let magicByte = buf.ReadInt8 ()
+      //let _magicByte = buf.ReadInt8 ()
+      buf.ShiftOffset 1 // magic byte
       let attrs = buf.ReadInt8 ()
       let timestamp = 
-        if ver >= 1s then 
+        if magicByte >= 1y then 
           buf.ReadInt64 ()
         else 
           0L
@@ -407,7 +465,7 @@ module Protocol =
       Message(crc,magicByte,attrs,timestamp,key,value)
 
     // NB: assumes that m.key and m.value use the same underlying array
-    static member ComputeCrc (ver:ApiVersion, m:Message) =
+    static member ComputeCrc (magicByte:int8, m:Message) =
       let offsetAtKey =
         m.value.Offset
         - 4 // key length
@@ -417,18 +475,17 @@ module Protocol =
         offsetAtKey
         - 1 // magicByte
         - 1 // attrs
-        - (if ver >= 1s then 8 else 0) // timestamp
+        - (if magicByte >= 1y then 8 else 0) // timestamp
       let offsetAtEnd = m.value.Offset + m.value.Count
       let readMessageSize = offsetAtEnd - offsetAfterCrc
       let crc32 = Crc.crc32 m.value.Array offsetAfterCrc readMessageSize
       int32 crc32
     
     // NB: assumes that m.key and m.value use the same underlying array
-    static member CheckCrc (ver:ApiVersion, m:Message) =
-      let crc' = Message.ComputeCrc (ver,m)
+    static member CheckCrc (magicByte:int8, m:Message) =
+      let crc' = Message.ComputeCrc (magicByte,m)
       if m.crc <> crc' then
         raise (CorruptCrc32Exception(sprintf "Corrupt message data. Computed CRC32=%i received CRC32=%i|key=%s" crc' m.crc (Binary.toString m.key)))
-
 
   [<NoEquality;NoComparison>]
   type MessageSetItem =
@@ -442,7 +499,7 @@ module Protocol =
   [<NoEquality;NoComparison>]
   type MessageSet =
     struct
-      // when specified, overrides the last offset
+      // when specified (in magic >= v2), overrides the last offset
       val lastOffset : int64
       val messages : MessageSetItem[]
       new (set) = { messages = set ; lastOffset = -1L }
@@ -450,23 +507,24 @@ module Protocol =
     end
   with
 
-    static member Size (ver:ApiVersion, x:MessageSet) =
+    static member Size (x:MessageSet) =
       let mutable size = 0
       for i = 0 to x.messages.Length - 1 do
-        let m = x.messages.[i].message
-        size <- size + 8 + 4 + (Message.Size (ver,m))
+        size <- size + 
+          8 + // offset
+          4 + // message size field
+          x.messages.[i].messageSize // (Message.Size m)
       size
 
-    static member Write (messageVer:ApiVersion, ms:MessageSet, buf:BinaryZipper) =
-      //for (o,ms,m) in ms.messages do
+    static member Write (ms:MessageSet, buf:BinaryZipper) =
       for x in ms.messages do
         buf.WriteInt64 x.offset
         buf.WriteInt32 x.messageSize
-        Message.Write (messageVer, x.message, buf)
+        Message.Write (x.message, buf)
 
     // NB: skipTooLarge=true is for scenarios where decompression is involved and a message set is being decoded from an individual message
     // which was itself too small.
-    static member Read (messageVer:ApiVersion, partition:Partition, ec:ErrorCode, messageSetSize:int, skipTooLarge:bool, buf:BinaryZipper) =
+    static member Read (magicByte:int8, partition:Partition, ec:ErrorCode, messageSetSize:int, skipTooLarge:bool, buf:BinaryZipper) =
       let mutable consumed = 0
       let arr = ResizeArray<_>()
       while consumed < messageSetSize && buf.Buffer.Count > 0 do
@@ -484,7 +542,7 @@ module Protocol =
           try
             let messageSetRemainder = messageSetRemainder - 12 // (Offset + MessageSize)
             if messageSetRemainder >= messageSize && buf.Buffer.Count >= messageSize then
-              let message = Message.Read (messageVer,buf)
+              let message = Message.Read (magicByte,buf)
               arr.Add (MessageSetItem(offset,messageSize,message))
             else
               let rem = min messageSetRemainder buf.Buffer.Count
@@ -507,56 +565,132 @@ module Protocol =
         consumed <- consumed + (buf.Buffer.Offset - o')
       MessageSet(arr.ToArray())
 
-    static member internal ReadFromRecordBatch (recordBatchSize:int, buf:BinaryZipper) =
-      let arr = ResizeArray<_>()
-      let mutable consumed = 0
-      let o = buf.Buffer.Offset
-      let firstOffset = buf.ReadInt64()
-      let _recordBatchLength = buf.ReadInt32 ()            
+    static member SizeRecordBatch (ms:MessageSet) =
+      //if ms.messages.Length = 0 then 0 else
+      let mutable size = RecordBatch.RECORD_BATCH_OVERHEAD
+      for i = 0 to ms.messages.Length - 1 do
+        let msi = ms.messages.[i]
+        size <- size + msi.messageSize + (Binary.sizeVarint msi.messageSize)
+      size
+
+    static member WriteRecordBatch (batchLength:int, ms:MessageSet, buf:BinaryZipper) =
+      let firstOffset = 0L //ms.messages.[0].offset
+      let firstTimestamp = ms.messages.[0].message.timestamp
+      let maxTimestamp = ms.messages.[ms.messages.Length - 1].message.timestamp
+      //let lastOffset = ms.messages.[ms.messages.Length - 1].offset
+      buf.WriteInt64 firstOffset
+      buf.WriteInt32 (batchLength - RecordBatch.LOG_OVERHEAD)
+      buf.WriteInt32 0 // partition leader epoch
+      buf.WriteInt8 2y // magic v2
+      let crcOffset = buf.Buffer.Offset
+      buf.ShiftOffset 4 // crc32 (written later)
+      let attributesOffset = buf.Buffer.Offset
+      buf.WriteInt16 0s // ((0s <<< 3) ||| 0s) // attributes (TODO)
+      buf.WriteInt32 (ms.messages.Length - 1) //(int (lastOffset - firstOffset)) // last offset delta
+      buf.WriteInt64 firstTimestamp // first timestamp
+      buf.WriteInt64 maxTimestamp // max timestamp
+      buf.WriteInt64 -1L // producer id
+      buf.WriteInt16 0s // producer epoch
+      buf.WriteInt32 -1  // first sequence
+      buf.WriteInt32 ms.messages.Length // num records
+      for i = 0 to ms.messages.Length - 1 do
+        let msi = ms.messages.[i]
+        let offsetDelta = int (msi.offset - firstOffset)
+        let timestampDelta = msi.message.timestamp - firstTimestamp
+        buf.WriteVarint msi.messageSize // length
+        buf.WriteInt8 0y // attributes
+        buf.WriteVarint64 timestampDelta // timestamp delta
+        buf.WriteVarint offsetDelta // offset delta
+        buf.WriteBytesVarint msi.message.key
+        buf.WriteBytesVarint msi.message.value
+        buf.WriteVarint 0 // headers length
+      let crcCount = batchLength - RecordBatch.ATTRIBUTES_OFFSET
+      let crc = Crc.crc32C buf.Buffer.Array attributesOffset crcCount
+      Binary.pokeInt32In (int crc) buf.Buffer.Array crcOffset
+
+    static member internal ReadFromRecordBatches (partition:Partition, ec:ErrorCode, messageSetSize:int, buf:BinaryZipper) =
+      let mss = ResizeArray<MessageSetItem>()
+      let mutable lastOffset = 0L
+      while buf.Buffer.Count > RecordBatch.RECORD_BATCH_OVERHEAD do
+        //printfn "reading record batch|buffer=%i" buf.Buffer.Count
+        let lo = MessageSet.ReadFromRecordBatch (partition,ec,messageSetSize,buf,mss)
+        lastOffset <- max lastOffset lo
+      MessageSet(mss.ToArray(),lastOffset)
+
+    static member private ReadFromRecordBatch (partition:Partition, ec:ErrorCode, messageSetSize:int, buf:BinaryZipper, mss:ResizeArray<MessageSetItem>) =
+      let firstOffset = buf.ReadInt64()      
+      let recordBatchLength = buf.ReadInt32 ()
+      let sizeInBytes = recordBatchLength + RecordBatch.LOG_OVERHEAD
+      if sizeInBytes < RecordBatch.RECORD_BATCH_OVERHEAD then
+        failwithf "record_batch_corrupt_size|first_offset=%i size=%i minimum_allowed_size=%i" firstOffset sizeInBytes RecordBatch.RECORD_BATCH_OVERHEAD
+      if recordBatchLength + RecordBatch.LOG_OVERHEAD > messageSetSize then        
+        let errMsg = sprintf "p=%i ec=%i o=%i mss=%i" partition ec firstOffset messageSetSize
+        raise (MessageTooBigException(errMsg, 2y, messageSetSize)) else
       let _partitionLeaderEpoch = buf.ReadInt32 ()
       let magicByte = buf.ReadInt8()
       let _crcSum = buf.ReadInt32()
-      let _batchAttributes = buf.ReadInt16()
+      let batchAttributes = buf.ReadInt16()
+      let compressionType = batchAttributes &&& int16 CompressionCodec.Mask // TODO: handle compression
+      let timestampType = 
+        if (batchAttributes &&& int16 TimestampType.MASK) = 0s then TimestampType.CREATE_TIME 
+        else TimestampType.LOG_APPEND_TIME
+      let isControl = batchAttributes &&& int16 0x20 > 0s
+      let isTx = batchAttributes &&& int16 0x10 > 0s
       let lastOffsetDelta = buf.ReadInt32()
       let lastOffset = firstOffset + int64 lastOffsetDelta      
       let firstTimestamp = buf.ReadInt64()
-      let _maxTimestamp = buf.ReadInt64()
-      do buf.ShiftOffset 14 // producer ID (int64) + producer epoch (int16) + first sequence (int32)
-      let _numRecords = buf.ReadInt32() // Note the response isn't guaranteed to contain every record in this count!
-      printfn "_recordBatchLength=%i recordBatchSize=%i _numRecords=%i last_offset=%i batch_attrs=%i" _recordBatchLength recordBatchSize _numRecords lastOffset _batchAttributes
-      consumed <- consumed + (buf.Buffer.Offset - o)
-      while consumed < recordBatchSize && buf.Buffer.Count > 0 do
-        //printfn "count=%i buffer=%i consumed=%i" arr.Count buf.Buffer.Count consumed
-        let o = buf.Buffer.Offset
+      let maxTimestamp = buf.ReadInt64()
+      let _producerId = buf.ReadInt64()
+      let _producerEpoch = buf.ReadInt16()
+      let _firstSequence = buf.ReadInt32()
+      let numRecords = buf.ReadInt32() // Note the response isn't guaranteed to contain every record in this count!
+      if numRecords < 0 then failwithf "invalid record count=%i" numRecords
+      //let mutable consumed = RecordBatch.RECORD_BATCH_OVERHEAD //buf.Buffer.Offset - recordBatchStart
+      //printfn "p=%i _recordBatchLength=%i mss=%i _numRecords=%i last_offset=%i batch_attrs=%i consumed=%i magic=%i tst=%i payload=%i" partition recordBatchLength messageSetSize numRecords lastOffset batchAttributes consumed magicByte timestampType payloadSize
+      let mutable readCount = 0
+      while numRecords > readCount && buf.Buffer.Count > 0 do
         let recordLength = buf.ReadVarint()
-        let rem = recordBatchSize - consumed
-        if recordLength > rem then
-          //printfn "Response does not contain a full message! Skip to the end."
-          buf.ShiftOffset (rem - 1)
-          consumed <- consumed + rem
+        let recordStart = buf.Buffer.Offset
+        if buf.Buffer.Count < recordLength then
+          //printfn "skipping|readCount=%i numRecords=%i buffer=%i recLength=%i ct=%i" readCount numRecords buf.Buffer.Count recordLength compressionType
+          buf.ShiftOffset buf.Buffer.Count
         else
+        try          
           let recordAttrributes = buf.ReadInt8()
-          let timestampDelta = buf.ReadVarint()
+          let timestampDelta = buf.ReadVarint64()
           let offsetDelta = buf.ReadVarint()
           let key = buf.ReadVarintBytes()
           let value = buf.ReadVarintBytes()
-          let _headersLength = buf.ReadVarint()          
-          //let headers = Array.zeroCreate headersLength
-          //for i = 0 to headers.Length - 1 do
-          //  let k = buf.ReadVarintString ()
-          //  let v = buf.ReadVarintString ()
-          //  headers.[i] <- (k,v)
+          let headersLength = buf.ReadVarint()          
+          if headersLength < 0 then failwithf "invalid headers length=%i" headersLength else
+          let headers = Array.zeroCreate headersLength
+          for i = 0 to headers.Length - 1 do
+            let k = buf.ReadVarintString ()
+            let v = buf.ReadVarintString ()
+            headers.[i] <- (k,v)
           let offset = firstOffset + int64 offsetDelta
-          let timestamp = firstTimestamp + int64 timestampDelta
-          printfn "key=%s value=%s headers=%i offset=%i length=%i timestamp=%i buffer=%i" (Binary.toString key) (Binary.toString value) _headersLength offset recordLength timestamp buf.Buffer.Count
+          let timestamp = 
+            if timestampType = TimestampType.LOG_APPEND_TIME then maxTimestamp
+            else firstTimestamp + timestampDelta
+          let readRecordLength = buf.Buffer.Offset - recordStart
+          if (readRecordLength <> recordLength) then failwithf "invalid_record_length|actual=%i expected=%i delta=%i offset=%i" readRecordLength recordLength offsetDelta offset
+          //consumed <- consumed + readRecordLength
+          //printfn "key=%s value=%s headers=%i offset=%i length=%i timestamp=%i buffer=%i consumed=%i" (Binary.toString key) (Binary.toString value) _headersLength offset recordLength timestamp buf.Buffer.Count consumed
           let message = Message(-1 (*crc*), magicByte, recordAttrributes, timestamp, key, value)
-          arr.Add (MessageSetItem(offset, recordLength, message))
-          consumed <- consumed + (buf.Buffer.Offset - o)
-      MessageSet(arr.ToArray(),lastOffset)
+          mss.Add (MessageSetItem(offset, recordLength, message))
+          readCount <- readCount + 1
+        with ex ->
+          let msg = sprintf "num_records=%i read_records=%i buffer=%i record_length=%i" numRecords readCount buf.Buffer.Count recordLength
+          raise (Exception(msg, ex))
+      //if numRecords = arr.Count then 
+      //  printfn "matching_record_counts|buffer=%i" buf.Buffer.Count
+      //printfn "p=%i consumed=%i _recordBatchLength=%i recordBatchSize=%i _numRecords=%i last_offset=%i batch_attrs=%i read_count=%i ct=%i" 
+      //  partition consumed recordBatchLength messageSetSize numRecords lastOffset batchAttributes readCount compressionType
+      lastOffset
 
-    static member CheckCrc (ver:ApiVersion, ms:MessageSet) =
+    static member CheckCrc (magicByte:int8, ms:MessageSet) =
       for x in ms.messages do
-        Message.CheckCrc (ver,x.message)
+        Message.CheckCrc (magicByte,x.message)
 
 
   /// A Kafka broker consists of a node id, host name and TCP port.
@@ -742,12 +876,13 @@ module Protocol =
         size <- size + (Binary.sizeString y.topic)
         size <- size + 4 // partition array size
         for z in y.partitions do
-          let mss = z.messageSetSize
-          size <- size + 8 + mss // partitionId (4), message set size (4), message set  
+          size <- size + 
+            4 + // partition
+            4 + // message set size
+            z.messageSetSize // message set
       size
 
     static member Write (ver:ApiVersion, x:ProduceRequest, buf:BinaryZipper) =
-      let messageVer = MessageVersions.produceReqMessage ver
       if ver >= 3s then 
         buf.WriteString x.transactionalId
       buf.WriteInt16 x.requiredAcks
@@ -760,7 +895,8 @@ module Protocol =
         for z in y.partitions do
           buf.WriteInt32 z.partition
           buf.WriteInt32 z.messageSetSize
-          MessageSet.Write (messageVer, z.messageSet, buf)
+          if ver >= 3s then MessageSet.WriteRecordBatch (z.messageSetSize, z.messageSet, buf)
+          else MessageSet.Write (z.messageSet, buf)
 
   and [<NoEquality;NoComparison>] ProduceResponsePartitionItem =
     struct
@@ -830,16 +966,18 @@ module Protocol =
   with
     // leverages mutability to reduce performance overhead
     static member Size (ver:ApiVersion, req:FetchRequest) =
-      let mutable size = 16 // replicaId + maxWaitTime + minBytes + topic array size (4 bytes each)
+      let mutable size = 12 // replicaId + maxWaitTime + minBytes
       if ver >= 3s then size <- size + 4 // maxBytes
       if ver >= 4s then size <- size + 1 // isolation level
+      size <- size + 4 // topic array size (4 bytes each)
       for i = 0 to req.topics.Length - 1 do 
         let (t,ps) = req.topics.[i]
         size <- size + (Binary.sizeString t) // topic name size
         size <- size + 4 // partition array size
         for (_,_,_,_) in ps do
-          size <- size + 16 // partition (4) + fetch offset (8) + maxBytes (4)
+          size <- size + 12 // partition (4) + fetch offset (8)
           if ver >= 5s then size <- size + 8 // log start offset
+          size <- size + 4 // maxBytes (4)
       size
 
     static member Write (ver:ApiVersion, req:FetchRequest, buf:BinaryZipper) =
@@ -879,23 +1017,42 @@ module Protocol =
       for i = 0 to topics.Length - 1 do
         let topic = buf.ReadString ()
         let numPartitions = buf.ReadInt32 ()
-        //printfn "numPartitions=%i" numPartitions
         let partitions = Array.zeroCreate numPartitions
-        //let mutable containsRecordBatch = false
         for j = 0 to partitions.Length - 1 do
-          let partition = buf.ReadInt32 ()          
+          let partition = buf.ReadInt32 ()
           let errorCode = buf.ReadInt16 ()
           let highWatermark = buf.ReadInt64 ()
-          let messageSetSize = buf.ReadInt32 ()          
-          //printfn "partition=%i ec=%i hwo=%i" partition errorCode highWatermark
-          //let messageSet = 
-          //  let magicByte = buf.TryPeekIn8AtOffset 16
-          //  if containsRecordBatch || magicByte >= 2y then 
-          //    containsRecordBatch <- true
-          //    MessageSet.ReadFromRecordBatch (messageSetSize, buf)
-          //  else MessageSet.Read (MessageVersions.fetchResMessage ver,partition,errorCode,messageSetSize,false,buf)
+          let _lastStableOffset = if ver >= 4s then buf.ReadInt64() else -1L
+          let _logStartOffset = if ver >= 5s then buf.ReadInt64() else -1L
+          let _numAbortedTxns = if ver >= 4s then buf.ReadInt32() else -1
+          let _abortedTxns =
+            if _numAbortedTxns >= 0 then
+              let _abortedTxns = Array.zeroCreate _numAbortedTxns
+              for k = 0 to _abortedTxns.Length - 1 do
+                let producerId = buf.ReadInt64 ()
+                let firstOffset = buf.ReadInt64 ()
+                _abortedTxns.[k] <- (producerId, firstOffset)
+              _abortedTxns
+            else
+              null
+          let messageSetSize = buf.ReadInt32 ()
+          if messageSetSize < 0 then failwithf "corrupt_fetch_response_partition_size|size=%i buffer=%i" messageSetSize buf.Buffer.Count
+          let innerBuf = 
+            let buf = ArraySegment(buf.Buffer.Array, buf.Buffer.Offset, messageSetSize)
+            BinaryZipper(buf)
           let messageSet = MessageSet.Read (MessageVersions.fetchResMessage ver,partition,errorCode,messageSetSize,false,buf)
+            //if messageSetSize = 0 then MessageSet([||]) else
+            //let magicByte = innerBuf.TryPeekIn8AtOffset 16
+            //if magicByte >= 2y || ver >= 3s then 
+            //  let ms = MessageSet.ReadFromRecordBatches (partition,errorCode,messageSetSize,innerBuf)
+            //  buf.ShiftOffset messageSetSize // TODO: remove this?
+            //  ms
+            //else 
+            //  MessageSet.Read (MessageVersions.fetchResMessage ver,partition,errorCode,messageSetSize,false,buf)
+              //MessageSet.Read (MessageVersions.fetchResMessage ver,partition,errorCode,messageSetSize,false,innerBuf)
+              //MessageSet.Read (magicByte,partition,errorCode,messageSetSize,false,innerBuf)
           partitions.[j] <- partition, errorCode, highWatermark, -1L, -1L, null, messageSetSize, messageSet
+          //buf.ShiftOffset messageSetSize // TODO: remove this?
         topics.[i] <- (topic,partitions)
       FetchResponse(throttleTime, topics)
 

--- a/src/kafunk/Utility/Async.fs
+++ b/src/kafunk/Utility/Async.fs
@@ -375,7 +375,7 @@ module Async =
       t 
       |> Task.extend (fun t -> 
         cts.Cancel () |> ignore
-        raise (OperationCanceledException("", t.Exception)))
+        raise (OperationCanceledException("cancelled!", t.Exception)))
     let at = Async.StartAsTask (a, cancellationToken = cts.Token)
     let! r = Task.WhenAny (t, at) |> awaitTaskCancellationAsError
     return r.Result }

--- a/src/kafunk/Utility/Binary.fs
+++ b/src/kafunk/Utility/Binary.fs
@@ -340,9 +340,6 @@ type BinaryZipper (buf:ArraySegment<byte>) =
     (value >>> 1) ^^^ -(value &&& 1)
 
   member __.WriteVarint (value:int) =
-    //if (value < 128) then
-    //  __.WriteByte (byte value)
-    //else
     let mutable v = (value <<< 1) ^^^ (value >>> 31)
     while ((v &&& 0xffffff80) <> 0) do
       let b = byte ((v &&& 0x7f) ||| 0x80)
@@ -459,4 +456,10 @@ type BinaryZipper (buf:ArraySegment<byte>) =
       __.WriteInt16 (int16 s.Length)
       let read = Encoding.UTF8.GetBytes(s, 0, s.Length, buf.Array, buf.Offset)
       __.ShiftOffset read
+
+  /// Creates a BinaryZipper and limits the size to the specified value.
+  /// NB: the child BinaryZipper is not linked and the parent must be shifted after the child is consumed.
+  member __.Limit (count:int) =
+    let buf = ArraySegment(__.Buffer.Array, __.Buffer.Offset, count)
+    BinaryZipper(buf)
 

--- a/src/kafunk/Versions.fs
+++ b/src/kafunk/Versions.fs
@@ -26,14 +26,15 @@ let internal byVersion (version:System.Version) : ApiKey -> ApiVersion =
       elif version >= V_0_9_0 then 1s
       else 0s
     | ApiKey.Fetch ->
-      if version >= V_0_10_0 then 2s
+      if version >= V_0_10_0 then 2s //4s //2s
       elif version >= V_0_9_0 then 1s
       else 0s
     | ApiKey.JoinGroup -> 
       if version >= V_0_10_1 then 1s
       else 0s
     | ApiKey.Offset ->
-      if version >= V_0_10_1 then 1s
+      //if version >= V_0_10_1 then 1s
+      if version >= V_0_10_1 then 0s
       else 0s
     | _ -> 
       0s
@@ -43,9 +44,9 @@ let internal byApiVersionResponse (x:ApiVersionsResponse) : ApiKey -> ApiVersion
   fun (key:ApiKey) -> 
     let (_,_,v) = x.apiVersions.[int key]
     match key with
-    | ApiKey.Produce -> min 2s v // TODO: any higher version for produce is currently crashing
-    | ApiKey.Fetch -> min 2s v // TODO: any higher version for offset is currently crashing
-    | ApiKey.Offset -> min 1s v // TODO: any higher version for offset is currently crashing
+    | ApiKey.Produce -> min 3s v
+    | ApiKey.Fetch -> min 5s v
+    | ApiKey.Offset -> min 0s v // TODO: any higher version for offset is currently crashing
     | ApiKey.Metadata -> min 5s v
     | ApiKey.OffsetCommit -> min 2s v
     | ApiKey.OffsetFetch -> min 2s v

--- a/tests/kafunk.Tests/App.config
+++ b/tests/kafunk.Tests/App.config
@@ -12,6 +12,16 @@
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
+    <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.0.4.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Crc32.NET" publicKeyToken="dc0b95cf99bf4e99" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.3.0" />
   </dependentAssembly>
@@ -23,11 +33,6 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.0.4.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.0.4.0" />
   </dependentAssembly>
   <dependentAssembly>

--- a/tests/kafunk.Tests/AsyncTest.fsx
+++ b/tests/kafunk.Tests/AsyncTest.fsx
@@ -9,9 +9,10 @@ open System.Threading.Tasks
 open System.Diagnostics
 
 
-let file = @"C:\code\kafunk\tests\kafunk.Tests\FetchResponse_RecordBatch.bin"
+//let file = @"C:\code\kafunk\tests\kafunk.Tests\FetchResponse_RecordBatch.bin"
+let file = @"C:\code\kafunk\tests\kafunk.Tests\fetch_p=0_p=3_daccd6f71ae945f5afe7cb57a3a7ee28.bin"
 let buf = System.IO.File.ReadAllBytes(file) |> Binary.ofArray |> BinaryZipper
-let res = FetchResponse.Read (2s, buf)
+let res = FetchResponse.Read (5s, buf)
 
 for (t,ps) in res.topics do
   for (p,_,hwo,_,_,_,_,ms) in ps do

--- a/tests/kafunk.Tests/CompressionTests.fs
+++ b/tests/kafunk.Tests/CompressionTests.fs
@@ -5,6 +5,12 @@ open NUnit.Framework
 open System
 open System.Text
 
+module Message =
+
+  let create value key attrs =
+    Message(0, 0y, (defaultArg attrs 0y), 0L, key, value)
+
+
 [<Test>]
 [<Category("Compression")>]
 let ``Compression.GZip should work`` () =
@@ -16,10 +22,10 @@ let ``Compression.GZip should work`` () =
     let message2 = Message.create (Binary.ofArray message2Bytes) (Binary.empty) None
     
     let inputMessage =
-        Compression.GZip.compress 0s (MessageSet.ofMessages 0s [message; message2])
+        Compression.GZip.compress (MessageSet.ofMessages [message; message2])
 
     let outputMessageSet =
-        Compression.GZip.decompress 0s inputMessage
+        Compression.GZip.decompress 0y inputMessage
 
     let messages = outputMessageSet.messages
     Assert.IsTrue (messages.Length = 2)

--- a/tests/kafunk.Tests/CompressionTests.fs
+++ b/tests/kafunk.Tests/CompressionTests.fs
@@ -10,6 +10,9 @@ module Message =
   let create value key attrs =
     Message(0, 0y, (defaultArg attrs 0y), 0L, key, value)
 
+let ofMessages ms =
+  MessageSet(ms |> Seq.map (fun m -> MessageSetItem (0L, Message.Size m, m)) |> Seq.toArray)
+
 
 [<Test>]
 [<Category("Compression")>]
@@ -22,7 +25,7 @@ let ``Compression.GZip should work`` () =
     let message2 = Message.create (Binary.ofArray message2Bytes) (Binary.empty) None
     
     let inputMessage =
-        Compression.GZip.compress (MessageSet.ofMessages [message; message2])
+        Compression.GZip.compress (ofMessages [message; message2])
 
     let outputMessageSet =
         Compression.GZip.decompress 0y inputMessage

--- a/tests/kafunk.Tests/ConfluentProducer.fsx
+++ b/tests/kafunk.Tests/ConfluentProducer.fsx
@@ -28,11 +28,11 @@ let batchSize = argiDefault 4 "100" |> Int32.Parse
 let messageSize = argiDefault 5 "10" |> Int32.Parse
 let parallelism = argiDefault 6 "1" |> Int32.Parse
 
-let payload = 
-  let bytes = Array.zeroCreate messageSize
-  let rng = Random()
-  rng.NextBytes bytes
-  bytes |> Encoding.UTF8.GetString
+let payload = "v"
+  //let bytes = Array.zeroCreate messageSize
+  //let rng = Random()
+  //rng.NextBytes bytes
+  //bytes |> Encoding.UTF8.GetString
 
 Log.info "running_producer_test|host=%s topic=%s count=%i batch_size=%i message_size=%i parallelism=%i"
   host topic N batchSize messageSize parallelism
@@ -72,14 +72,15 @@ let go = async {
 
   let! _ = Async.StartChild monitor
 
-  use producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8))
+  //use producer = new Producer<Null, string>(config, null, new StringSerializer(Encoding.UTF8))
+  use producer = new Producer<string, string>(config, new StringSerializer(Encoding.UTF8), new StringSerializer(Encoding.UTF8))
 
   producer.OnLog |> Event.add (fun e ->
     Log.info "librdkafka|name=%s facility=%s message=%s" e.Name e.Facility e.Message
   )
 
   let produce (m:string) = async {
-    let! res = producer.ProduceAsync(topic, null, m, true) |> Async.awaitTaskCancellationAsError
+    let! res = producer.ProduceAsync(topic, "k", m, true) |> Async.awaitTaskCancellationAsError
     return res }
 
   let produce = 

--- a/tests/kafunk.Tests/ConfluentProducer.fsx
+++ b/tests/kafunk.Tests/ConfluentProducer.fsx
@@ -1,4 +1,4 @@
-﻿#r "bin/release/confluent.kafka.dll"
+﻿#r "bin/release/net45/confluent.kafka.dll"
 #load "Refs.fsx"
 #time "on"
 
@@ -28,11 +28,11 @@ let batchSize = argiDefault 4 "100" |> Int32.Parse
 let messageSize = argiDefault 5 "10" |> Int32.Parse
 let parallelism = argiDefault 6 "1" |> Int32.Parse
 
-let payload = "v"
-  //let bytes = Array.zeroCreate messageSize
-  //let rng = Random()
-  //rng.NextBytes bytes
-  //bytes |> Encoding.UTF8.GetString
+let payload = //"v"
+  let bytes = Array.zeroCreate messageSize
+  let rng = Random()
+  rng.NextBytes bytes
+  bytes |> Encoding.UTF8.GetString
 
 Log.info "running_producer_test|host=%s topic=%s count=%i batch_size=%i message_size=%i parallelism=%i"
   host topic N batchSize messageSize parallelism
@@ -44,8 +44,9 @@ let config =
       
     "bootstrap.servers", box host 
     "acks", box "all"
-    //"batch.size", box 16384
-    "linger.ms", box 100
+    //"batch.size", box 1000000
+    "batch.num.messages", box 100000
+    "linger.ms", box 1000
     "max.in.flight.requests.per.connection", box 1
 
   ] |> toDict

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -32,16 +32,18 @@ let go = async {
         requestRetryPolicy = KafkaConfig.DefaultRequestRetryPolicy,
         //version = Versions.V_0_10_1,
         version = Versions.V_0_9_0,
-        autoApiVersions = false)
+        autoApiVersions = false,
+        clientId = "leo")
     Kafka.connAsync connConfig
   let consumerConfig = 
     ConsumerConfig.create (
       groupId = group, 
       topic = topic, 
       autoOffsetReset = AutoOffsetReset.StartFromTime Time.EarliestOffset,
-      fetchMaxBytes = 1000,
-      fetchMaxBytesOverride = 10000,
-      fetchMinBytes = 1,
+      fetchMaxBytes = 5000000,
+      fetchMaxBytesTotal = 50000000,
+      //fetchMaxBytesOverride = 100000,
+      //fetchMinBytes = 0,
       //fetchMaxWaitMs = 1000,
       fetchBufferSize = 1,
       sessionTimeout = 30000,
@@ -66,19 +68,21 @@ let go = async {
   let! _ = Async.StartChild showProgress
 
   let handle (s:ConsumerState) (ms:ConsumerMessageSet) = async {
-    use! _cnc = Async.OnCancel (fun () -> Log.warn "cancelling_handler")    
+    //use! _cnc = Async.OnCancel (fun () -> Log.warn "cancelling_handler")    
     //for m in ms.messageSet.messages do
     //  Log.info "key=%s" (Binary.toString m.message.key)
-    Log.trace "consuming_message_set|topic=%s partition=%i count=%i size=%i os=[%i-%i] ts=[%O] hwo=%i lag=%i"
-      ms.topic
-      ms.partition
-      (ms.messageSet.messages.Length)
-      (ConsumerMessageSet.size ms)
-      (ConsumerMessageSet.firstOffset ms)
-      (ConsumerMessageSet.lastOffset ms)
-      (ConsumerMessageSet.firstTimestamp ms)
-      (ms.highWatermarkOffset)
-      (ConsumerMessageSet.lag ms) }
+    //Log.info "consuming_message_set|topic=%s partition=%i count=%i size=%i os=[%i-%i] ts=[%O] hwo=%i lag=%i"
+    //  ms.topic
+    //  ms.partition
+    //  (ms.messageSet.messages.Length)
+    //  (ConsumerMessageSet.size ms)
+    //  (ConsumerMessageSet.firstOffset ms)
+    //  (ConsumerMessageSet.lastOffset ms)
+    //  (ConsumerMessageSet.firstTimestamp ms)
+    //  (ms.highWatermarkOffset)
+    //  (ConsumerMessageSet.lag ms) 
+    return ()
+  }
 
   use counter = Metrics.counter Log 5000
 

--- a/tests/kafunk.Tests/Consumer.fsx
+++ b/tests/kafunk.Tests/Consumer.fsx
@@ -30,9 +30,10 @@ let go = async {
         //[KafkaUri.parse "localhost:9092" ; KafkaUri.parse "localhost:9093" ; KafkaUri.parse "localhost:9094"],
         tcpConfig = chanConfig,
         requestRetryPolicy = KafkaConfig.DefaultRequestRetryPolicy,
-        //version = Versions.V_0_10_1,
-        version = Versions.V_0_9_0,
-        autoApiVersions = false,
+        version = Versions.V_0_10_1,
+        autoApiVersions = true,
+        //version = Versions.V_0_9_0,
+        //autoApiVersions = false,
         clientId = "leo")
     Kafka.connAsync connConfig
   let consumerConfig = 
@@ -40,9 +41,9 @@ let go = async {
       groupId = group, 
       topic = topic, 
       autoOffsetReset = AutoOffsetReset.StartFromTime Time.EarliestOffset,
-      fetchMaxBytes = 5000000,
+      fetchMaxBytes = 500000,
       fetchMaxBytesTotal = 50000000,
-      //fetchMaxBytesOverride = 100000,
+      fetchMaxBytesOverride = 1000000,
       //fetchMinBytes = 0,
       //fetchMaxWaitMs = 1000,
       fetchBufferSize = 1,

--- a/tests/kafunk.Tests/Fetch.fsx
+++ b/tests/kafunk.Tests/Fetch.fsx
@@ -6,18 +6,29 @@ open Kafunk
 open System
 open Refs
 
-Log.MinLevel <- LogLevel.Trace
+//Log.MinLevel <- LogLevel.Trace
+let Log = Log.create __SOURCE_FILE__
 let host = argiDefault 1 "localhost"
 let topic = argiDefault 2 "absurd-topic"
+
+let tcpConfig = 
+  ChanConfig.create (
+    requestTimeout = TimeSpan.FromSeconds 60.0,
+    receiveBufferSize = 8192 * 50,
+    sendBufferSize = 8192 * 50,
+    connectRetryPolicy = ChanConfig.DefaultConnectRetryPolicy,
+    requestRetryPolicy = ChanConfig.DefaultRequestRetryPolicy)
 
 let connCfg = 
   KafkaConfig.create (
     [KafkaUri.parse host], 
+    tcpConfig = tcpConfig,
     version=Versions.V_0_10_1, 
     //autoApiVersions=true,
     //version=Versions.V_0_9_0, 
     clientId = "leo"
   )
+
 let conn = Kafka.conn connCfg
 
 //let offsetRange =
@@ -45,20 +56,65 @@ let conn = Kafka.conn connCfg
 
 //let ps = [| (0,0L,0L,10000) ; (1,0L,0L,10000); (2,0L,0L,10000) ; (3,0L,0L,10000) |]
 //let ps = [| (0,0L,-1L,10000000) ; (3,0L,-1L,10000000) |]
-let ps = [| (3,0L,0L,10000) |]
+//let ps = [| (3,0L,0L,10000) |]
 //let ps = [| (3,0L,0L,100000) ; (0,0L,0L,100000) |]
 //let ps = [| (0,25000L,0L,10000) ; (3,0L,0L,10000) |]
-let fetchReq = FetchRequest(-1, 100, 0, [| topic, ps |], 10000000, 0y)
+//let fetchReq = FetchRequest(-1, 100, 0, [| topic, ps |], 10000000, 0y)
 
-let fetchRes = 
-  Kafka.fetch conn fetchReq
-  |> Async.RunSynchronously
+//let fetchRes = 
+//  Kafka.fetch conn fetchReq
+//  |> Async.RunSynchronously
 
-for (tn,pmds) in fetchRes.topics do
-  for (p,ec,hmo,_,logStartOffset,_,mss,ms) in pmds do
-    printfn "topic=%s p=%i ec=%i hwm=%i mss=%i mc=%i" tn p ec hmo mss ms.messages.Length
-    for x in ms.messages do
-      let o,ms,m = x.offset, x.messageSize, x.message
-      //printfn "p=%i o=%i size=%i timestamp=%O key=%s value=%s" p o ms (DateTime.FromUnixMilliseconds m.timestamp) (m.key |> Binary.toString) (m.value |> Binary.toString)
-      ()
+//for (tn,pmds) in fetchRes.topics do
+//  for p in pmds do    
+//    let ec = p.errorCode
+//    let hmo = p.highWatermarkOffset
+//    let mss = p.messageSetSize
+//    let ms = p.messageSet
+//    let p = p.partition
+//    printfn "topic=%s p=%i ec=%i hwm=%i mss=%i mc=%i" tn p ec hmo mss ms.messages.Length
+//    for x in ms.messages do
+//      let o,ms,m = x.offset, x.messageSize, x.message
+//      //printfn "p=%i o=%i size=%i timestamp=%O key=%s value=%s" p o ms (DateTime.FromUnixMilliseconds m.timestamp) (m.key |> Binary.toString) (m.value |> Binary.toString)
+//      ()
 
+let go = async {
+
+  let! offsetRange = Offsets.offsetRange conn topic []
+
+  let maxBytesTotal = 10000000
+  let maxBytesPartition = 10000000
+
+  let rec fetch p o = async {    
+    let ps = [| (p,o,0L,maxBytesPartition) |]
+    let req = FetchRequest(-1, 100, 1, [| topic, ps |], maxBytesTotal, 0y)
+    let! res = Kafka.fetch conn req
+    let (_,ps) = res.topics.[0]
+    let p = ps.[0]
+    let count = p.messageSet.messages.Length
+    if count = 0 then return (None,0) else
+    let lastOffset = p.messageSet.messages.[count - 1].offset
+    let nextOffset = lastOffset + 1L
+    return (Some nextOffset,count) }
+
+  use counter = Metrics.counter Log 5000
+
+  let fetch = 
+    fetch
+    |> Metrics.throughputAsync2To counter (fun (_,_,(_,count)) -> count)  
+
+  let rec fetchProc p o = async {
+    let! (nextOffset,count) = fetch p o
+    match nextOffset with
+    | None -> return ()
+    | Some next -> return! fetchProc p next }
+
+  return!
+    offsetRange
+    |> Map.toSeq
+    |> Seq.map (fun (p,(o,_)) -> fetchProc p o)
+    |> Async.Parallel
+    |> Async.Ignore }
+
+try Async.RunSynchronously go
+with ex -> Log.error "%O" ex

--- a/tests/kafunk.Tests/Fetch.fsx
+++ b/tests/kafunk.Tests/Fetch.fsx
@@ -6,34 +6,49 @@ open Kafunk
 open System
 open Refs
 
+Log.MinLevel <- LogLevel.Trace
 let host = argiDefault 1 "localhost"
 let topic = argiDefault 2 "absurd-topic"
 
-let connCfg = KafkaConfig.create ([KafkaUri.parse host], version=Versions.V_0_10_1)
+let connCfg = 
+  KafkaConfig.create (
+    [KafkaUri.parse host], 
+    version=Versions.V_0_10_1, 
+    //autoApiVersions=true,
+    //version=Versions.V_0_9_0, 
+    clientId = "leo"
+  )
 let conn = Kafka.conn connCfg
 
-let offsetRange =
-  Offsets.offsetRange conn topic []
-  |> Async.RunSynchronously
+//let offsetRange =
+//  Offsets.offsetRange conn topic []
+//  |> Async.RunSynchronously
 
-printfn "offset response topics=%A" offsetRange
+//printfn "offset response topics=%A" offsetRange
 
-for kvp in offsetRange do
-  let p = kvp.Key
-  let e,l = kvp.Value
-  printfn "p=%i earliest=%i latest=%i" p e l
+//for kvp in offsetRange do
+//  let p = kvp.Key
+//  let e,l = kvp.Value
+//  printfn "p=%i earliest=%i latest=%i" p e l
 
-let ps =
-  offsetRange 
-  |> Seq.choose (fun kvp -> 
-    let p = kvp.Key
-    let e,l = kvp.Value
-    if l - e > 0L then Some (p,e,0L,1000000)
-    else None)
-  |> Seq.truncate 10
-  |> Seq.toArray
+//let ps =
+//  offsetRange 
+//  |> Seq.choose (fun kvp -> 
+//    let p = kvp.Key
+//    let e,l = kvp.Value
+//    if l - e > 0L then Some (p,e,0L,1000000)
+//    else None)
+//  |> Seq.truncate 10
+//  |> Seq.toArray
 
-let fetchReq = FetchRequest(-1, 0, 0, [| topic, ps |], 0, 0y)
+//let fetchReq = FetchRequest(-1, 0, 0, [| topic, ps |], 0, 0y)
+
+//let ps = [| (0,0L,0L,10000) ; (1,0L,0L,10000); (2,0L,0L,10000) ; (3,0L,0L,10000) |]
+//let ps = [| (0,0L,-1L,10000000) ; (3,0L,-1L,10000000) |]
+let ps = [| (3,0L,0L,10000) |]
+//let ps = [| (3,0L,0L,100000) ; (0,0L,0L,100000) |]
+//let ps = [| (0,25000L,0L,10000) ; (3,0L,0L,10000) |]
+let fetchReq = FetchRequest(-1, 100, 0, [| topic, ps |], 10000000, 0y)
 
 let fetchRes = 
   Kafka.fetch conn fetchReq
@@ -41,9 +56,9 @@ let fetchRes =
 
 for (tn,pmds) in fetchRes.topics do
   for (p,ec,hmo,_,logStartOffset,_,mss,ms) in pmds do
-    printfn "topic=%s partition=%i error=%i logStartOffset=%i hwm=%i message_set_size=%i messages=%i" tn p ec logStartOffset hmo mss ms.messages.Length
+    printfn "topic=%s p=%i ec=%i hwm=%i mss=%i mc=%i" tn p ec hmo mss ms.messages.Length
     for x in ms.messages do
       let o,ms,m = x.offset, x.messageSize, x.message
-      printfn "message offset=%i size=%i timestamp=%O key=%s" 
-                o ms (DateTime.FromUnixMilliseconds m.timestamp) (m.key |> Binary.toString)
+      //printfn "p=%i o=%i size=%i timestamp=%O key=%s value=%s" p o ms (DateTime.FromUnixMilliseconds m.timestamp) (m.key |> Binary.toString) (m.value |> Binary.toString)
+      ()
 

--- a/tests/kafunk.Tests/Produce.fsx
+++ b/tests/kafunk.Tests/Produce.fsx
@@ -1,0 +1,53 @@
+﻿#load "Refs.fsx"
+#time "on"
+
+open FSharp.Control
+open Kafunk
+open System
+open System.Diagnostics
+open System.Threading
+open Refs
+
+Log.MinLevel <- LogLevel.Trace
+let Log = Log.create __SOURCE_FILE__
+
+let host = argiDefault 1 "localhost"
+let topic = argiDefault 2 "absurd-topic"
+
+let key = "k"B |> Binary.ofArray
+let value = "v"B |> Binary.ofArray
+
+let magicByte = 2y
+let ts = 0L
+  //if magicByte > 1y then int64 (DateTime.UtcNow - UnixEpoch).TotalMilliseconds
+  //else 0L
+let m = Message(0, magicByte, 0y, ts, key, value)
+
+let ms' = 
+  if magicByte > 1y then Message.SizeRecord 0L 0 m
+  else Message.Size m
+
+let ms = MessageSet([| MessageSetItem(0L, ms', m) |])
+
+let mss =  
+  if magicByte > 1y then MessageSet.SizeRecordBatch ms
+  else MessageSet.Size ms
+
+let req = ProduceRequest(RequiredAcks.AllInSync, 10000, [|ProduceRequestTopicMessageSet(topic, [| ProduceRequestPartitionMessageSet(1, mss, ms) |]) |], null)
+
+let kafkaConfig = 
+  KafkaConfig.create (
+    [KafkaUri.parse host], 
+    version = Versions.V_0_10_1,
+    autoApiVersions = true,
+    clientId = "rdkafka"
+  )
+
+let conn = Kafka.conn kafkaConfig
+
+let res = Kafka.produce conn req |> Async.RunSynchronously
+
+for t in res.topics do
+  for p in t.partitions do
+    printfn "t=%s p=%i o=%i ec=%i" t.topic p.partition p.offset p.errorCode
+

--- a/tests/kafunk.Tests/Producer.fsx
+++ b/tests/kafunk.Tests/Producer.fsx
@@ -21,11 +21,12 @@ let produceType = argiDefault 7 "2" |> Int32.Parse
 
 let volumeMB = (N * int64 messageSize) / int64 1000000
 
-let payload = "hi"B
-  //let bytes = Array.zeroCreate messageSize
-  //let rng = Random()
-  //rng.NextBytes bytes
-  //bytes
+let payload = 
+  //"v"B
+  let bytes = Array.zeroCreate messageSize
+  let rng = Random()
+  rng.NextBytes bytes
+  bytes
 
 let batchCount = int (N / int64 batchSize)
 
@@ -55,7 +56,7 @@ let connCfg =
     bootstrapConnectRetryPolicy = KafkaConfig.DefaultBootstrapConnectRetryPolicy,
     //bootstrapConnectRetryPolicy = RetryPolicy.constantBoundedMs 1000 3,
     version = Versions.V_0_10_1,
-    autoApiVersions = false
+    autoApiVersions = true
     )
 
 let conn = Kafka.conn connCfg

--- a/tests/kafunk.Tests/Producer.fsx
+++ b/tests/kafunk.Tests/Producer.fsx
@@ -55,6 +55,8 @@ let connCfg =
     //requestRetryPolicy = RetryPolicy.constantBoundedMs 1000 10,
     bootstrapConnectRetryPolicy = KafkaConfig.DefaultBootstrapConnectRetryPolicy,
     //bootstrapConnectRetryPolicy = RetryPolicy.constantBoundedMs 1000 3,
+    //version = Versions.V_0_9_0,
+    //autoApiVersions = false
     version = Versions.V_0_10_1,
     autoApiVersions = true
     )

--- a/tests/kafunk.Tests/kafunk.Tests.fsproj
+++ b/tests/kafunk.Tests/kafunk.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="AssignmentStrategyTests.fs" />
     <Compile Include="SVarTests.fs" />
     <None Include="Refs.fsx" />
+    <None Include="Produce.fsx" />
     <Compile Include="Metadata.fsx" />
     <None Include="Producer.fsx" />
     <Compile Include="Fetch.fsx" />


### PR DESCRIPTION
Adds support for the v11 protocol. More specifically, supports v5 of Fetch API and v3 of Produce API, both of which make use of the v2 message format (RecordBatch).